### PR TITLE
Bug: Include package.json files needed for Node.js resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Bug: Include `package.json` files that are needed for Node.js resolution.
+  [#12](https://github.com/FormidableLabs/trace-deps/issues/12)
+
 ## 0.1.0
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ _Returns_:
 
 * **Only handles single string dependencies**: `require`, `require.resolve`, and dynamic `import()` support calls with variables or other expressions like `require(aVar)`, `import(process.env.VAL + "more-stuff")`. This library presently only supports calls with a **single string** and nothing else. We have a [tracking ticket](https://github.com/FormidableLabs/trace-deps/issues/2) to consider expanding support for things like partial evaluation.
 
+* **Includes `package.json` files used in resolution**: As this is a Node.js-focused library, to follow the Node.js [module resolution algorithm](https://nodejs.org/api/modules.html#modules_all_together) which notably uses intermediate encountered `package.json` files to determine how to resolve modules. This means that we include a lot of `package.json` files that seemingly aren't directly imported (such as a `const pkg = require("mod/package.json")`) because they are needed for the list of all traced files to together resolve correctly if all on disk together.
+
 [npm_img]: https://badge.fury.io/js/trace-deps.svg
 [npm_site]: http://badge.fury.io/js/trace-deps
 [trav_img]: https://api.travis-ci.com/FormidableLabs/trace-deps.svg

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -82,17 +82,41 @@ const traceFile = async ({ srcPath, ignores = [], tracedDepPaths = new Set() } =
   // TODO(5): Consider limiting concurrent resolution.
   // https://github.com/FormidableLabs/trace-deps/issues/5
   const basedir = path.dirname(srcPath);
-  const depPaths = await Promise
-    .all(depNames.map((depName) => resolve(depName, { basedir }).catch((err) => {
-      // Convert to more useful error.
-      throw new Error(`Encountered resolution error in ${srcPath} for ${depName}: ${err}`);
-    })))
+  // Start with the resolve path and any package.json used to get there.
+  const depObjs = await Promise
+    .all(depNames.map(async (depName) => {
+      // Track last package file before a resolution because we need to include
+      // it for proper resolution if used.
+      let lastPkgFile;
+      return resolve(depName, {
+        basedir,
+        packageFilter: (pkg, pkgfile) => {
+          lastPkgFile = pkgfile;
+          return pkg;
+        }
+      })
+        // Add in package files if any.
+        .then((depPath) => ({ depPath, pkgPath: lastPkgFile }))
+        .catch((err) => {
+        // Convert to more useful error.
+          throw new Error(`Encountered resolution error in ${srcPath} for ${depName}: ${err}`);
+        });
+    }))
     // Remove core standard Node.js libraries (`path`, etc.)
-    .then((allPaths) => allPaths.filter((depPath, i) => depPath !== depNames[i]));
+    .then((allPaths) => allPaths.filter(({ depPath }, i) => depPath !== depNames[i]));
+
+  // Extract to different types of paths.
+  const depPaths = depObjs.map(({ depPath }) => depPath);
+  const pkgPaths = depObjs.map(({ pkgPath }) => pkgPath).filter(Boolean);
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   tracedDepPaths.add(srcPath);
-  const resolvedDepPaths = await _recurseDeps({ depPaths, ignores, tracedDepPaths });
+  const resolvedDepPaths = [].concat(
+    // Add all needed package.json files
+    pkgPaths,
+    // Add dependencies from recursion.
+    await _recurseDeps({ depPaths, ignores, tracedDepPaths })
+  );
 
   // Make unique and return.
   return uniq(resolvedDepPaths);

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -85,18 +85,21 @@ const traceFile = async ({ srcPath, ignores = [], tracedDepPaths = new Set() } =
   // Start with the resolve path and any package.json used to get there.
   const depObjs = await Promise
     .all(depNames.map(async (depName) => {
-      // Track last package file before a resolution because we need to include
-      // it for proper resolution if used.
-      let lastPkgFile;
+      // Capture all package.json files encountered in node resolution.
+      //
+      // Related issues:
+      // - Optimization: https://github.com/FormidableLabs/trace-deps/issues/13
+      // - Upstream bug (pkg.json): https://github.com/FormidableLabs/trace-deps/issues/14
+      const pkgPaths = [];
       return resolve(depName, {
         basedir,
         packageFilter: (pkg, pkgfile) => {
-          lastPkgFile = pkgfile;
+          pkgPaths.push(pkgfile);
           return pkg;
         }
       })
         // Add in package files if any.
-        .then((depPath) => ({ depPath, pkgPath: lastPkgFile }))
+        .then((depPath) => ({ depPath, pkgPaths }))
         .catch((err) => {
         // Convert to more useful error.
           throw new Error(`Encountered resolution error in ${srcPath} for ${depName}: ${err}`);
@@ -107,13 +110,13 @@ const traceFile = async ({ srcPath, ignores = [], tracedDepPaths = new Set() } =
 
   // Extract to different types of paths.
   const depPaths = depObjs.map(({ depPath }) => depPath);
-  const pkgPaths = depObjs.map(({ pkgPath }) => pkgPath).filter(Boolean);
+  const allPkgPaths = depObjs.reduce((memo, { pkgPaths }) => memo.concat(pkgPaths), []);
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   tracedDepPaths.add(srcPath);
   const resolvedDepPaths = [].concat(
     // Add all needed package.json files
-    pkgPaths,
+    allPkgPaths,
     // Add dependencies from recursion.
     await _recurseDeps({ depPaths, ignores, tracedDepPaths })
   );

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -443,6 +443,37 @@ describe("lib/trace", () => {
         "node_modules/two/index.js"
       ]));
     });
+
+    it("handles requires with arguments", async () => {
+      mock({
+        "hi.js": `
+          const one = require("one")();
+          require("two")("my message for two");
+
+          const variableDep = "shouldnt-find";
+          require(variableDep)();
+        `,
+        node_modules: {
+          one: {
+            "package.json": stringify({
+              main: "index.js"
+            }),
+            "index.js": "module.exports = () => 'one';"
+          },
+          two: {
+            "package.json": stringify({
+              main: "index.js"
+            }),
+            "index.js": "module.exports = (msg) => `two :${msg}`;"
+          }
+        }
+      });
+
+      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+        "node_modules/one/index.js",
+        "node_modules/two/index.js"
+      ]));
+    });
   });
 
   describe("traceFiles", () => {

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -625,6 +625,8 @@ describe("lib/trace", () => {
           const variableDep = "shouldnt-find";
           require(variableDep)();
         `,
+        // TODO(13) Optimization: Verify `package.json` is not included
+        // https://github.com/FormidableLabs/trace-deps/issues/13
         "package.json": stringify({
           description: "should be unused",
           main: "hi.js"
@@ -642,6 +644,8 @@ describe("lib/trace", () => {
             `,
             "another-one": {
               // Should use _index_ and not package.json
+              // TODO(13) Optimization: Verify `another-one/package.json` is not included
+              // https://github.com/FormidableLabs/trace-deps/issues/13
               "index.js": "module.exports = 'another one';",
               "package.json": stringify({
                 description: "should be not included because it points to a bad path",

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -300,9 +300,13 @@ describe("lib/trace", () => {
 
       expect(await traceFile({ srcPath: "hi.mjs" })).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
+        "node_modules/nested-flattened-three/package.json",
         "node_modules/one/index.mjs",
+        "node_modules/one/package.json",
         "node_modules/three/index.mjs",
-        "node_modules/two/index.mjs"
+        "node_modules/three/package.json",
+        "node_modules/two/index.mjs",
+        "node_modules/two/package.json"
       ]));
     });
 
@@ -399,9 +403,13 @@ describe("lib/trace", () => {
 
       expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
         "node_modules/four/index.js",
+        "node_modules/four/package.json",
         "node_modules/one/index.js",
+        "node_modules/one/package.json",
         "node_modules/three/index.js",
-        "node_modules/two/index.js"
+        "node_modules/three/package.json",
+        "node_modules/two/index.js",
+        "node_modules/two/package.json"
       ]));
     });
 
@@ -455,7 +463,9 @@ describe("lib/trace", () => {
         ]
       })).to.eql(fullPath([
         "node_modules/one/index.js",
-        "node_modules/two/index.js"
+        "node_modules/one/package.json",
+        "node_modules/two/index.js",
+        "node_modules/two/package.json"
       ]));
     });
   });
@@ -527,9 +537,13 @@ describe("lib/trace", () => {
         "second.js"
       ] })).to.eql(fullPath([
         "node_modules/one/index.js",
+        "node_modules/one/package.json",
         "node_modules/three/index.mjs",
         "node_modules/three/node_modules/nested-three/index.mjs",
-        "node_modules/two/index.js"
+        "node_modules/three/node_modules/nested-three/package.json",
+        "node_modules/three/package.json",
+        "node_modules/two/index.js",
+        "node_modules/two/package.json"
       ]));
     });
 
@@ -591,13 +605,17 @@ describe("lib/trace", () => {
         "second.mjs"
       ] })).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
+        "node_modules/nested-flattened-three/package.json",
         "node_modules/one/index.mjs",
+        "node_modules/one/package.json",
         "node_modules/three/index.mjs",
-        "node_modules/two/index.mjs"
+        "node_modules/three/package.json",
+        "node_modules/two/index.mjs",
+        "node_modules/two/package.json"
       ]));
     });
 
-    it.only("handles requires with arguments and local libs", async () => {
+    it("handles requires with arguments and local libs", async () => {
       mock({
         "hi.js": "module.exports = require('./ho');",
         "ho.js": `
@@ -653,12 +671,12 @@ describe("lib/trace", () => {
         "node_modules/one/and-more/diff-path.js",
         "node_modules/one/and-more/package.json",
         "node_modules/one/another-one/index.js",
-        "node_modules/one/another-one/package.json", // TODO: Shouldn't be here.
+        "node_modules/one/another-one/package.json",
         "node_modules/one/index.js",
         "node_modules/one/package.json",
         "node_modules/two/index.js",
         "node_modules/two/package.json",
-        "package.json" // TODO: Shouldn't be here.
+        "package.json"
       ]));
     });
   });


### PR DESCRIPTION
Add intermediate traversed `package.json` files to traced files output because they are a necessary part of how Node.js resolves files on disk. Fixes #12 