### PR TITLE
Feature: Return dynamic import "misses"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ Changes
 
 **Breaking**
 
-* Feature: Change `traceFile|traceFiles` signature to `{ dependencies, misses }` and report imports that cannot be traced.
+* Feature: Change `traceFile|traceFiles` return object shape to `{ dependencies, misses }` to include imports that cannot be traced.
   [#25](https://github.com/FormidableLabs/trace-deps/issues/25)
 
 **Features**
 
-* Feature: Add inference for template literal strings in imports.
+* Feature: Add tracing for template literal strings in imports (e.g., ``require(`tmpl-str`)``).
 
 ## 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ Changes
 
 ## UNRELEASED
 
-* TODO
+**Breaking**
+
+* Feature: Change `traceFile|traceFiles` signature to `{ dependencies, misses }` and report imports that cannot be traced.
   [#25](https://github.com/FormidableLabs/trace-deps/issues/25)
-* Feature: Add inference for template literal strings.
+
+**Features**
+
+* Feature: Add inference for template literal strings in imports.
 
 ## 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+## UNRELEASED
+
+* TODO
+  [#25](https://github.com/FormidableLabs/trace-deps/issues/25)
+* Feature: Add inference for template literal strings.
+
 ## 0.2.4
 
 * Bug: Search for `index.json` files when no `package.json:main` is specified.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,18 @@ _Parameters_:
 
 _Returns_:
 
-* (`Promise<Array<string>>`): list of absolute paths to on-disk dependencies
+* (`Promise<Object>`): Dependencies and other information.
+    * `dependencies` (`Array<string>`): list of absolute paths to on-disk dependencies
+    * `missing` (`Object.<string, Array<Object>`): Mapping of file absolute paths on disk to an array of imports that `trace-deps` was **not** able to resolve (dynamic requires, etc.). The object contained in the value array is structured as follows:
+        * `src` (`string`): The source code snippet of the import in question (e.g., `"require(A_VAR)"`)
+        * `start`, `end` (`number`): The starting / ending character indexes in the source code string corresponding to the source file.
+        * `loc` (`Object`): Line / column information for the code string at issue taking the form:
+            ```js
+            {
+              start: { line: Number, column: Number},
+              end:   { line: Number, column: Number}
+            }
+            ```
 
 ### `traceFiles({ srcPaths, ignores })`
 
@@ -48,7 +59,7 @@ _Parameters_:
 
 _Returns_:
 
-* (`Promise<Array<string>>`): list of absolute paths to on-disk dependencies
+* (`Promise<Object>`): Dependencies and other information. See `traceFile()` for object shape.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Returns_:
 
 * (`Promise<Object>`): Dependencies and other information.
     * `dependencies` (`Array<string>`): list of absolute paths to on-disk dependencies
-    * `missing` (`Object.<string, Array<Object>`): Mapping of file absolute paths on disk to an array of imports that `trace-deps` was **not** able to resolve (dynamic requires, etc.). The object contained in the value array is structured as follows:
+    * `misses` (`Object.<string, Array<Object>`): Mapping of file absolute paths on disk to an array of imports that `trace-deps` was **not** able to resolve (dynamic requires, etc.). The object contained in the value array is structured as follows:
         * `src` (`string`): The source code snippet of the import in question (e.g., `"require(A_VAR)"`)
         * `start`, `end` (`number`): The starting / ending character indexes in the source code string corresponding to the source file.
         * `loc` (`Object`): Line / column information for the code string at issue taking the form:

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -23,7 +23,10 @@ const getStringArg = ({ args }) => {
     && firstArg.quasis.length === 1
     && firstArg.quasis[0].type === "TemplateElement"
   ) {
-    return firstArg.quasis[0].value.cooked;
+    // Cooked can technically be undefined.
+    // https://2ality.com/2016/09/template-literal-revision.html#solution
+    const { cooked } = firstArg.quasis[0].value;
+    return typeof cooked === "undefined" ? null : cooked;
   }
 
   // Default: No usable string.

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -6,9 +6,34 @@
 
 const walk = require("acorn-node/walk");
 
+// Helper to extract a usable string argument.
+const getStringArg = ({ args }) => {
+  // Only continue with exactly **one** argument.
+  const firstArg = args.length === 1 ? args[0] : {};
+
+  // String literal.
+  if (firstArg.type === "Literal") {
+    return firstArg.value;
+  }
+
+  // Template string: Require a single TemplateElement quasis and nothing else.
+  if (
+    firstArg.type === "TemplateLiteral"
+    && !firstArg.expressions.length
+    && firstArg.quasis.length === 1
+    && firstArg.quasis[0].type === "TemplateElement"
+  ) {
+    return firstArg.quasis[0].value.cooked;
+  }
+
+  // Default: No usable string.
+  return null;
+};
+
 // Extract all dependency strings from require/import statements.
 const getDeps = (ast) => {
   const deps = new Set();
+  const misses = new Set(); // TODO(misses): Correct data structure?
 
   walk.simple(ast, {
     // Node
@@ -24,9 +49,11 @@ const getDeps = (ast) => {
       // Only get first argument if only one to ensure we have a single string
       // literal for `require()` and `import()`.
       const args = node.arguments || [];
-      const firstArg = args.length === 1 ? args[0] : {};
+      const stringArg = getStringArg({ args });
 
       // Node: `require`
+      //
+      // ## Hits
       //
       // ```js
       // require("foo");
@@ -42,11 +69,95 @@ const getDeps = (ast) => {
       //   value: foo
       //   raw: '"foo"'
       // ```
+      //
+      // ```js
+      // require(`foo`);
+      // ```
+      //
+      // ```yml
+      // type: CallExpression
+      // callee:
+      //   type: Identifier
+      //   name: require
+      // arguments:
+      // - type: TemplateLiteral
+      //   expressions: []
+      //   quasis:
+      //     - type: TemplateElement
+      //       value:
+      //         raw: foo
+      //         cooked: foo
+      //       tail: true
+      // ```
+      //
+      // ## Misses
+      //
+      // ```js
+      // require(A_VAR); // TODO(misses): TEST
+      // ```
+      //
+      // ```yml
+      // type: CallExpression
+      // callee:
+      //   type: Identifier
+      //   name: require
+      // arguments:
+      //   - type: Identifier
+      //     name: A_VAR
+      // ```
+      //
+      // ```js
+      // require("a"|`a`|A_VAR + B_VAR|"_b"|`_b`); // TODO(misses): TEST
+      // ```
+      //
+      // ```yml
+      // type: CallExpression
+      // callee:
+      //   type: Identifier
+      //   name: require
+      // arguments:
+      // - type: BinaryExpression
+      //   left:
+      //     type: <Something>
+      //     <...>
+      //   operator: +
+      //   right:
+      //     type: <Something>
+      //     <...>
+      // ```
+      //
+      // ```js
+      // require(`a_template_string_${A_VAR}`);  // TODO(misses): TEST
+      // ```
+      //
+      // ```yml
+      // type: CallExpression
+      // callee:
+      //   type: Identifier
+      //   name: require
+      // arguments:
+      // - type: TemplateLiteral
+      //   expressions:
+      //     - type: Identifier
+      //       name: A_VAR
+      //   quasis:
+      //     - type: TemplateElement
+      //       value:
+      //         raw: a_template_string_
+      //         cooked: a_template_string_
+      //       tail: false
+      //     - type: TemplateElement
+      //       value:
+      //         raw: ''
+      //         cooked: ''
+      //       tail: true
+      // ```
+      //
       if (
         callee.type === "Identifier" && callee.name === "require"
-        && firstArg.type === "Literal"
+        && stringArg !== null
       ) {
-        deps.add(firstArg.value);
+        deps.add(stringArg);
       }
 
       // Node: `require.resolve`
@@ -74,8 +185,8 @@ const getDeps = (ast) => {
       if (callee.type === "MemberExpression"
         && callee.object.type === "Identifier" && callee.object.name === "require"
         && callee.property.type === "Identifier" && callee.property.name === "resolve"
-        && firstArg.type === "Literal") {
-        deps.add(firstArg.value);
+        && stringArg !== null) {
+        deps.add(stringArg);
       }
     },
 
@@ -112,6 +223,23 @@ const getDeps = (ast) => {
     //   type: Literal
     //   value: foo
     //   raw: '"foo"'
+    // ```
+    //
+    // ```js
+    // import(`foo`); // TODO: TEST_MATCH
+    // ```
+    //
+    // ```yml
+    // type: ImportExpression
+    // source:
+    //   type: TemplateLiteral
+    //   expressions: []
+    //   quasis:
+    //     - type: TemplateElement
+    //       value:
+    //         raw: foo
+    //         cooked: foo
+    //       tail: true
     // ```
     ImportExpression({ source } = {}) {
       source = source || {};
@@ -216,6 +344,9 @@ const getDeps = (ast) => {
     // https://github.com/FormidableLabs/trace-deps/issues/3
   });
 
+  console.log("TODO(missing)", { misses });
+
+  // TODO(missing): Change signature, add BREAKING note.
   return deps;
 };
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -45,6 +45,15 @@ const getDeps = ({ ast, src }) => {
   const dependencies = new Set();
   const misses = [];
 
+  // Lazy convert to string for missed import string extraction.
+  let srcStr = null;
+  const getSrcStr = () => {
+    if (srcStr === null) {
+      srcStr = src.toString();
+    }
+    return srcStr;
+  };
+
   walk.simple(ast, {
     // Node
     // eslint-disable-next-line complexity
@@ -169,7 +178,7 @@ const getDeps = ({ ast, src }) => {
         }
 
         // Miss.
-        return void misses.push(getMiss({ node, src }));
+        return void misses.push(getMiss({ node, src: getSrcStr() }));
       }
 
       // Node: `require.resolve`
@@ -203,7 +212,7 @@ const getDeps = ({ ast, src }) => {
         }
 
         // Miss.
-        return void misses.push(getMiss({ node, src }));
+        return void misses.push(getMiss({ node, src: getSrcStr() }));
       }
     },
 
@@ -267,7 +276,7 @@ const getDeps = ({ ast, src }) => {
       }
 
       // Miss.
-      return void misses.push(getMiss({ node, src }));
+      return void misses.push(getMiss({ node, src: getSrcStr() }));
     },
 
     // ESM: `export { <var> } from`

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -31,14 +31,15 @@ const getStringArg = ({ args }) => {
 };
 
 // Extract all dependency strings from require/import statements.
-const getDeps = (ast) => {
+const getDeps = ({ ast, src }) => {
   const deps = new Set();
-  const misses = new Set(); // TODO(misses): Correct data structure?
+  const misses = [];
 
   walk.simple(ast, {
     // Node
     // eslint-disable-next-line complexity
     CallExpression(node) {
+      const { start, end } = node;
       // Populate callee with empty defaults.
       const callee = {
         object: {},
@@ -93,7 +94,7 @@ const getDeps = (ast) => {
       // ## Misses
       //
       // ```js
-      // require(A_VAR); // TODO(misses): TEST
+      // require(A_VAR); // TODO(misses): TEST -- TODO_HERE
       // ```
       //
       // ```yml
@@ -153,11 +154,18 @@ const getDeps = (ast) => {
       //       tail: true
       // ```
       //
-      if (
-        callee.type === "Identifier" && callee.name === "require"
-        && stringArg !== null
-      ) {
-        deps.add(stringArg);
+      if (callee.type === "Identifier" && callee.name === "require") {
+        // Hit.
+        if (stringArg !== null) {
+          return void deps.add(stringArg);
+        }
+
+        // Miss.
+        return void misses.push({
+          start,
+          end,
+          src: src.slice(start, end).toString()
+        });
       }
 
       // Node: `require.resolve`

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -30,6 +30,13 @@ const getStringArg = ({ args }) => {
   return null;
 };
 
+const getMiss = ({ node: { start, end, loc }, src }) => ({
+  start,
+  end,
+  loc,
+  src: src.slice(start, end).toString()
+});
+
 // Extract all dependency strings from require/import statements.
 const getDeps = ({ ast, src }) => {
   const deps = new Set();
@@ -39,7 +46,6 @@ const getDeps = ({ ast, src }) => {
     // Node
     // eslint-disable-next-line complexity
     CallExpression(node) {
-      const { start, end } = node;
       // Populate callee with empty defaults.
       const callee = {
         object: {},
@@ -94,7 +100,7 @@ const getDeps = ({ ast, src }) => {
       // ## Misses
       //
       // ```js
-      // require(A_VAR); // TODO(misses): TEST -- TODO_HERE
+      // require(A_VAR);
       // ```
       //
       // ```yml
@@ -108,7 +114,7 @@ const getDeps = ({ ast, src }) => {
       // ```
       //
       // ```js
-      // require("a"|`a`|A_VAR + B_VAR|"_b"|`_b`); // TODO(misses): TEST
+      // require("a"|`a`|A_VAR + B_VAR|"_b"|`_b`);
       // ```
       //
       // ```yml
@@ -128,7 +134,7 @@ const getDeps = ({ ast, src }) => {
       // ```
       //
       // ```js
-      // require(`a_template_string_${A_VAR}`);  // TODO(misses): TEST
+      // require(`a_template_string_${A_VAR}`);
       // ```
       //
       // ```yml
@@ -153,7 +159,6 @@ const getDeps = ({ ast, src }) => {
       //         cooked: ''
       //       tail: true
       // ```
-      //
       if (callee.type === "Identifier" && callee.name === "require") {
         // Hit.
         if (stringArg !== null) {
@@ -161,11 +166,7 @@ const getDeps = ({ ast, src }) => {
         }
 
         // Miss.
-        return void misses.push({
-          start,
-          end,
-          src: src.slice(start, end).toString()
-        });
+        return void misses.push(getMiss({ node, src }));
       }
 
       // Node: `require.resolve`
@@ -192,9 +193,14 @@ const getDeps = ({ ast, src }) => {
       // ```
       if (callee.type === "MemberExpression"
         && callee.object.type === "Identifier" && callee.object.name === "require"
-        && callee.property.type === "Identifier" && callee.property.name === "resolve"
-        && stringArg !== null) {
-        deps.add(stringArg);
+        && callee.property.type === "Identifier" && callee.property.name === "resolve") {
+        // Hit.
+        if (stringArg !== null) {
+          return void deps.add(stringArg);
+        }
+
+        // Miss.
+        return void misses.push(getMiss({ node, src }));
       }
     },
 
@@ -234,7 +240,7 @@ const getDeps = ({ ast, src }) => {
     // ```
     //
     // ```js
-    // import(`foo`); // TODO: TEST_MATCH
+    // import(`foo`);
     // ```
     //
     // ```yml
@@ -249,11 +255,16 @@ const getDeps = ({ ast, src }) => {
     //         cooked: foo
     //       tail: true
     // ```
-    ImportExpression({ source } = {}) {
-      source = source || {};
-      if (source.type === "Literal") {
-        deps.add(source.value);
+    ImportExpression(node) {
+      const sourceArg = getStringArg({ args: [node.source || {}] });
+
+      // Hit.
+      if (sourceArg !== null) {
+        return void deps.add(sourceArg);
       }
+
+      // Miss.
+      return void misses.push(getMiss({ node, src }));
     },
 
     // ESM: `export { <var> } from`
@@ -352,7 +363,7 @@ const getDeps = ({ ast, src }) => {
     // https://github.com/FormidableLabs/trace-deps/issues/3
   });
 
-  console.log("TODO(missing)", { misses });
+  console.log("TODO(missing)", JSON.stringify({ misses }, null, 2));
 
   // TODO(missing): Change signature, add BREAKING note.
   return deps;

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -42,7 +42,7 @@ const getMiss = ({ node: { start, end, loc }, src }) => ({
 
 // Extract all dependency strings from require/import statements.
 const getDeps = ({ ast, src }) => {
-  const deps = new Set();
+  const dependencies = new Set();
   const misses = [];
 
   walk.simple(ast, {
@@ -165,7 +165,7 @@ const getDeps = ({ ast, src }) => {
       if (callee.type === "Identifier" && callee.name === "require") {
         // Hit.
         if (stringArg !== null) {
-          return void deps.add(stringArg);
+          return void dependencies.add(stringArg);
         }
 
         // Miss.
@@ -199,7 +199,7 @@ const getDeps = ({ ast, src }) => {
         && callee.property.type === "Identifier" && callee.property.name === "resolve") {
         // Hit.
         if (stringArg !== null) {
-          return void deps.add(stringArg);
+          return void dependencies.add(stringArg);
         }
 
         // Miss.
@@ -223,7 +223,7 @@ const getDeps = ({ ast, src }) => {
     ImportDeclaration({ source } = {}) {
       source = source || {};
       if (source.type === "Literal") {
-        deps.add(source.value);
+        dependencies.add(source.value);
       }
     },
 
@@ -263,7 +263,7 @@ const getDeps = ({ ast, src }) => {
 
       // Hit.
       if (sourceArg !== null) {
-        return void deps.add(sourceArg);
+        return void dependencies.add(sourceArg);
       }
 
       // Miss.
@@ -336,7 +336,7 @@ const getDeps = ({ ast, src }) => {
     ExportNamedDeclaration({ source } = {}) {
       source = source || {};
       if (source.type === "Literal") {
-        deps.add(source.value);
+        dependencies.add(source.value);
       }
     },
 
@@ -356,7 +356,7 @@ const getDeps = ({ ast, src }) => {
     ExportAllDeclaration({ source } = {}) {
       source = source || {};
       if (source.type === "Literal") {
-        deps.add(source.value);
+        dependencies.add(source.value);
       }
     }
 
@@ -366,10 +366,7 @@ const getDeps = ({ ast, src }) => {
     // https://github.com/FormidableLabs/trace-deps/issues/3
   });
 
-  console.log("TODO(missing)", JSON.stringify({ misses }, null, 2));
-
-  // TODO(missing): Change signature, add BREAKING note.
-  return deps;
+  return { dependencies, misses };
 };
 
 module.exports = {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -80,7 +80,8 @@ const traceFile = async ({
 
   // Get dependencies.
   const ast = parse(src, { sourceType: "module", locations: true });
-  const depNames = uniq(getDeps({ ast, src }))
+  const { dependencies } = getDeps({ ast, src });
+  const depNames = uniq(dependencies)
     // Remove ignored names.
     .filter((depName) => !ignores.some((i) => depName === i || depName.startsWith(`${i}/`)));
   if (!depNames.length) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -79,7 +79,8 @@ const traceFile = async ({
   });
 
   // Get dependencies.
-  const depNames = uniq(getDeps({ ast: parse(src, { sourceType: "module" }), src }))
+  const ast = parse(src, { sourceType: "module", locations: true });
+  const depNames = uniq(getDeps({ ast, src }))
     // Remove ignored names.
     .filter((depName) => !ignores.some((i) => depName === i || depName.startsWith(`${i}/`)));
   if (!depNames.length) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -12,6 +12,10 @@ const { getLastPackage } = require("./package");
 const resolve = promisify(require("resolve"));
 const readFile = promisify(fs.readFile);
 const uniq = (items) => Array.from(new Set(items)).sort();
+const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
+  memo[key] = obj[key];
+  return memo;
+}, {});
 
 // HELPER: Recursively track and trace dependency paths.
 // - `srcPaths`: If provided, **don't** add to resolvedDepPaths
@@ -24,7 +28,8 @@ const _recurseDeps = async ({
   _tracedDepPaths
 }) => {
   // Start **only** with depPaths.
-  let resolvedDepPaths = Array.from(depPaths);
+  let dependencies = Array.from(depPaths);
+  let missing = {};
 
   // If srcPaths is provided, now **replace** depPaths.
   // (Allows easier accommodation of `traceFile` vs. `traceFiles`)
@@ -39,16 +44,20 @@ const _recurseDeps = async ({
 
       // Recurse.
       // eslint-disable-next-line no-use-before-define
-      const recursedDepPaths = await traceFile(
+      const traced = await traceFile(
         { srcPath: depPath, ignores, allowMissing, _tracedDepPaths }
       );
 
       // Aggregate.
-      resolvedDepPaths = resolvedDepPaths.concat(recursedDepPaths);
+      missing = traced.missing;
+      dependencies = dependencies.concat(traced.dependencies);
     }
   }
 
-  return resolvedDepPaths;
+  return {
+    dependencies,
+    missing
+  };
 };
 
 /**
@@ -68,6 +77,7 @@ const _recurseDeps = async ({
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
  * @returns {Promise<Object>}                   dependencies and other information
  */
+// eslint-disable-next-line max-statements
 const traceFile = async ({
   srcPath,
   ignores = [],
@@ -84,15 +94,26 @@ const traceFile = async ({
     throw err.code === "ENOENT" ? new Error(`Could not find source file: ${srcPath}`) : err;
   });
 
-  // Get dependencies.
+  // Start results object.
+  const results = {
+    dependencies: [],
+    missing: {}
+  };
+
+  // Parse and extract.
   const ast = parse(src, { sourceType: "module", locations: true });
-  const { dependencies } = getDeps({ ast, src });
+  const { dependencies, missing } = getDeps({ ast, src });
+
+  // Merge in missing.
+  results.missing[path.resolve(srcPath)] = missing;
+
+  // Handle dependencies.
   const depNames = uniq(dependencies)
     // Remove ignored names.
     .filter((depName) => !ignores.some((i) => depName === i || depName.startsWith(`${i}/`)));
   if (!depNames.length) {
     // Base case: no additional dependencies.
-    return [];
+    return results;
   }
 
   // Resolve to full file paths.
@@ -148,15 +169,18 @@ const traceFile = async ({
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   _tracedDepPaths.add(srcPath);
-  const resolvedDepPaths = [].concat(
+  const recursed = await _recurseDeps({ depPaths, ignores, allowMissing, _tracedDepPaths });
+
+  results.missing = sortObj({ ...results.missing, ...recursed.missing });
+  results.dependencies = uniq([].concat(
     // Add all needed package.json files
     allPkgPaths,
     // Add dependencies from recursion.
-    await _recurseDeps({ depPaths, ignores, allowMissing, _tracedDepPaths })
-  );
+    recursed.dependencies
+  ));
 
   // Make unique and return.
-  return uniq(resolvedDepPaths);
+  return results;
 };
 
 /**
@@ -176,10 +200,13 @@ const traceFiles = async ({
   _tracedDepPaths = new Set()
 } = {}) => {
   // Recurse all source files.
-  const resolvedDepPaths = await _recurseDeps({ srcPaths, ignores, allowMissing, _tracedDepPaths });
+  const results = await _recurseDeps({ srcPaths, ignores, allowMissing, _tracedDepPaths });
 
   // Make unique and return.
-  return uniq(resolvedDepPaths);
+  return {
+    missing: sortObj(results.missing),
+    dependencies: uniq(results.dependencies)
+  };
 };
 
 module.exports = {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -79,7 +79,7 @@ const traceFile = async ({
   });
 
   // Get dependencies.
-  const depNames = uniq(getDeps(parse(src, { sourceType: "module" })))
+  const depNames = uniq(getDeps({ ast: parse(src, { sourceType: "module" }), src }))
     // Remove ignored names.
     .filter((depName) => !ignores.some((i) => depName === i || depName.startsWith(`${i}/`)));
   if (!depNames.length) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -66,7 +66,7 @@ const _recurseDeps = async ({
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
- * @returns {Promise<Object>}                   dependencies and other information.
+ * @returns {Promise<Object>}                   dependencies and other information
  */
 const traceFile = async ({
   srcPath,
@@ -167,7 +167,7 @@ const traceFile = async ({
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
- * @returns {Promise<Object>}                   dependencies and other information.
+ * @returns {Promise<Object>}                   dependencies and other information
  */
 const traceFiles = async ({
   srcPaths,

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -29,7 +29,7 @@ const _recurseDeps = async ({
 }) => {
   // Start **only** with depPaths.
   let dependencies = Array.from(depPaths);
-  let missing = {};
+  let misses = {};
 
   // If srcPaths is provided, now **replace** depPaths.
   // (Allows easier accommodation of `traceFile` vs. `traceFiles`)
@@ -49,14 +49,14 @@ const _recurseDeps = async ({
       );
 
       // Aggregate.
-      missing = traced.missing;
+      misses = traced.misses;
       dependencies = dependencies.concat(traced.dependencies);
     }
   }
 
   return {
     dependencies,
-    missing
+    misses
   };
 };
 
@@ -97,15 +97,17 @@ const traceFile = async ({
   // Start results object.
   const results = {
     dependencies: [],
-    missing: {}
+    misses: {}
   };
 
   // Parse and extract.
   const ast = parse(src, { sourceType: "module", locations: true });
-  const { dependencies, missing } = getDeps({ ast, src });
+  const { dependencies, misses } = getDeps({ ast, src });
 
-  // Merge in missing.
-  results.missing[path.resolve(srcPath)] = missing;
+  // Merge in misses.
+  if (misses.length) {
+    results.misses[path.resolve(srcPath)] = misses;
+  }
 
   // Handle dependencies.
   const depNames = uniq(dependencies)
@@ -171,7 +173,7 @@ const traceFile = async ({
   _tracedDepPaths.add(srcPath);
   const recursed = await _recurseDeps({ depPaths, ignores, allowMissing, _tracedDepPaths });
 
-  results.missing = sortObj({ ...results.missing, ...recursed.missing });
+  results.misses = sortObj({ ...results.misses, ...recursed.misses });
   results.dependencies = uniq([].concat(
     // Add all needed package.json files
     allPkgPaths,
@@ -204,7 +206,7 @@ const traceFiles = async ({
 
   // Make unique and return.
   return {
-    missing: sortObj(results.missing),
+    misses: sortObj(results.misses),
     dependencies: uniq(results.dependencies)
   };
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -49,7 +49,7 @@ const _recurseDeps = async ({
       );
 
       // Aggregate.
-      misses = traced.misses;
+      misses = { ...misses, ...traced.misses };
       dependencies = dependencies.concat(traced.dependencies);
     }
   }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -16,7 +16,13 @@ const uniq = (items) => Array.from(new Set(items)).sort();
 // HELPER: Recursively track and trace dependency paths.
 // - `srcPaths`: If provided, **don't** add to resolvedDepPaths
 // - `depPaths`: If provided, **do** add to resolvedDepPaths
-const _recurseDeps = async ({ srcPaths, depPaths = [], ignores, allowMissing, tracedDepPaths }) => {
+const _recurseDeps = async ({
+  srcPaths,
+  depPaths = [],
+  ignores,
+  allowMissing,
+  _tracedDepPaths
+}) => {
   // Start **only** with depPaths.
   let resolvedDepPaths = Array.from(depPaths);
 
@@ -27,14 +33,14 @@ const _recurseDeps = async ({ srcPaths, depPaths = [], ignores, allowMissing, tr
   // TODO(6): Consider parallelizing file traversal
   // https://github.com/FormidableLabs/trace-deps/issues/6
   for (const depPath of depPaths) {
-    if (!tracedDepPaths.has(depPath) && (/\.(js|mjs)$/).test(depPath)) {
+    if (!_tracedDepPaths.has(depPath) && (/\.(js|mjs)$/).test(depPath)) {
       // Mark encountered to avoid future recursion.
-      tracedDepPaths.add(depPath);
+      _tracedDepPaths.add(depPath);
 
       // Recurse.
       // eslint-disable-next-line no-use-before-define
       const recursedDepPaths = await traceFile(
-        { srcPath: depPath, ignores, allowMissing, tracedDepPaths }
+        { srcPath: depPath, ignores, allowMissing, _tracedDepPaths }
       );
 
       // Aggregate.
@@ -48,25 +54,25 @@ const _recurseDeps = async ({ srcPaths, depPaths = [], ignores, allowMissing, tr
 /**
  * Trace and return on-disk locations of all file dependencies from a source file.
  *
- * **Note**: An internal set, `tracedDepPaths`, tracks every file we encounter
+ * **Note**: An internal set, `_tracedDepPaths`, tracks every file we encounter
  * before recursion and won't recurse additional times once we hit a file. This
  * is used internally within a `traceFile` call and for any use of `traceFiles`.
  * This does mean if you are repeatedly calling `traceFile` with the same entry
- * point file you should manually create and pass a shared `tracedDepPaths` set
+ * point file you should manually create and pass a shared `_tracedDepPaths` set
  * to avoid unnecessary additional tracing.
  *
- * @param {*}             opts                options object
- * @param {string}        opts.srcPath        source file path to trace
- * @param {Array<string>} opts.ignores        list of package prefixes to ignore
- * @param {Object}        opts.allowMissing   map packages to list of allowed missing package
- * @param {Set}           opts.tracedDepPaths tracked dependencies
- * @returns {Promise<Array<string>>}          list of absolute paths to on-disk dependencies
+ * @param {*}             opts                  options object
+ * @param {string}        opts.srcPath          source file path to trace
+ * @param {Array<string>} opts.ignores          list of package prefixes to ignore
+ * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
+ * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
+ * @returns {Promise<Object>}                   dependencies and other information.
  */
 const traceFile = async ({
   srcPath,
   ignores = [],
   allowMissing = {},
-  tracedDepPaths = new Set()
+  _tracedDepPaths = new Set()
 } = {}) => {
   if (!srcPath) {
     throw new Error("Empty source file path");
@@ -141,12 +147,12 @@ const traceFile = async ({
   const allPkgPaths = depObjs.reduce((memo, { pkgPaths }) => memo.concat(pkgPaths), []);
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
-  tracedDepPaths.add(srcPath);
+  _tracedDepPaths.add(srcPath);
   const resolvedDepPaths = [].concat(
     // Add all needed package.json files
     allPkgPaths,
     // Add dependencies from recursion.
-    await _recurseDeps({ depPaths, ignores, allowMissing, tracedDepPaths })
+    await _recurseDeps({ depPaths, ignores, allowMissing, _tracedDepPaths })
   );
 
   // Make unique and return.
@@ -156,21 +162,21 @@ const traceFile = async ({
 /**
  * Trace and return on-disk locations of all file dependencies from source files.
  *
- * @param {*}             opts                options object
- * @param {Array<string>} opts.srcPaths       source file paths to trace
- * @param {Array<string>} opts.ignores        list of package prefixes to ignore
- * @param {Object}        opts.allowMissing   map packages to list of allowed missing package
- * @param {Set}           opts.tracedDepPaths tracked dependencies
- * @returns {Promise<Array<string>>}          list of absolute paths to on-disk dependencies
+ * @param {*}             opts                  options object
+ * @param {Array<string>} opts.srcPaths         source file paths to trace
+ * @param {Array<string>} opts.ignores          list of package prefixes to ignore
+ * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
+ * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
+ * @returns {Promise<Object>}                   dependencies and other information.
  */
 const traceFiles = async ({
   srcPaths,
   ignores = [],
   allowMissing = {},
-  tracedDepPaths = new Set()
+  _tracedDepPaths = new Set()
 } = {}) => {
   // Recurse all source files.
-  const resolvedDepPaths = await _recurseDeps({ srcPaths, ignores, allowMissing, tracedDepPaths });
+  const resolvedDepPaths = await _recurseDeps({ srcPaths, ignores, allowMissing, _tracedDepPaths });
 
   // Make unique and return.
   return uniq(resolvedDepPaths);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -21,7 +21,8 @@ describe("index", () => {
         "exported.js": "module.exports = 'exported';"
       });
 
-      expect(await traceFile({ srcPath: "exported.js" })).to.eql([]);
+      const { dependencies } = await traceFile({ srcPath: "exported.js" });
+      expect(dependencies).to.eql([]);
     });
   });
 
@@ -31,7 +32,8 @@ describe("index", () => {
         "exported.js": "module.exports = 'exported';"
       });
 
-      expect(await traceFiles({ srcPaths: ["exported.js"] })).to.eql([]);
+      const { dependencies } = await traceFiles({ srcPaths: ["exported.js"] });
+      expect(dependencies).to.eql([]);
     });
   });
 });

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -414,7 +414,8 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, misses } = await traceFile({ srcPath: "hi.mjs" });
+      const srcPath = "hi.mjs";
+      const { dependencies, misses } = await traceFile({ srcPath });
       expect(dependencies).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
         "node_modules/nested-flattened-three/package.json",
@@ -425,6 +426,9 @@ describe("lib/trace", () => {
         "node_modules/two/index.mjs",
         "node_modules/two/package.json"
       ]));
+      expect(missesSrcs({ misses, srcPath })).to.eql([
+        "import(variableDep)"
+      ]);
     });
 
     it("handles lower directories than where file is located", async () => {
@@ -462,6 +466,7 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
+      expect(misses).to.eql({});
     });
 
     it("handles circular dependencies", async () => {
@@ -530,6 +535,7 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
+      expect(misses).to.eql({});
     });
 
     it("ignores specified names and prefixes", async () => {
@@ -587,6 +593,7 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
+      expect(misses).to.eql({});
     });
 
     it("handles try/catch misses requires", async () => {
@@ -687,6 +694,7 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
+      expect(misses).to.eql({});
     });
 
     it("still errors on missing imports in a catch", async () => {
@@ -785,16 +793,10 @@ describe("lib/trace", () => {
         "node_modules/two/index.json",
         "node_modules/two/package.json"
       ]));
+      expect(misses).to.eql({});
     });
 
-    // TODO(misses): require(`foo`);
-    // TODO(misses): require(`foo_${A_VAR}`);
-    // TODO(misses): require("foo_" + A_VAR);
-    // TODO(misses): require(A_VAR + "bar");
-    // TODO(misses): require("foo_" + "bar");
-    //
-    // TODO(misses): ALL REQUIRES but for `require.resolve()`
-    // TODO(misses): ALL REQUIRES but for `import()`
+    it("reports on complex, nested misses"); // TODO
   });
 
   describe("traceFiles", () => {
@@ -1015,5 +1017,7 @@ describe("lib/trace", () => {
         "package.json"
       ]));
     });
+
+    it("reports on complex, nested misses"); // TODO
   });
 });

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -803,6 +803,7 @@ describe("lib/trace", () => {
     it("handles empty sources list", async () => {
       const { dependencies, misses } = await traceFiles({ srcPaths: [] });
       expect(dependencies).to.eql([]);
+      expect(misses).to.eql({});
     });
 
     it("handles no dependencies", async () => {
@@ -812,6 +813,7 @@ describe("lib/trace", () => {
 
       const { dependencies, misses } = await traceFiles({ srcPaths: ["hi.js"] });
       expect(dependencies).to.eql([]);
+      expect(misses).to.eql({});
     });
 
     it("handles dynamic imports with .js", async () => {
@@ -877,6 +879,9 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
+      expect(missesSrcs({ misses, srcPath: "second.js" })).to.eql([
+        "import(variableDep)"
+      ]);
     });
 
     it("handles dynamic imports with .mjs", async () => {
@@ -946,6 +951,9 @@ describe("lib/trace", () => {
         "node_modules/two/index.mjs",
         "node_modules/two/package.json"
       ]));
+      expect(missesSrcs({ misses, srcPath: "second.mjs" })).to.eql([
+        "import(variableDep)"
+      ]);
     });
 
     it("handles requires with arguments and local libs", async () => {
@@ -1016,6 +1024,9 @@ describe("lib/trace", () => {
         "node_modules/two/package.json",
         "package.json"
       ]));
+      expect(missesSrcs({ misses, srcPath: "ho.js" })).to.eql([
+        "require(variableDep)"
+      ]);
     });
 
     it("reports on complex, nested misses"); // TODO

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -47,8 +47,9 @@ describe("lib/trace", () => {
         "hi.js": "module.exports = 'hi';"
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql([]);
+      expect(misses).to.eql({});
     });
 
     it("handles requires with .js", async () => {
@@ -92,7 +93,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
@@ -139,7 +140,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.mjs" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.mjs",
         "node_modules/one/package.json",
@@ -194,7 +195,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.mjs" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/four/index.mjs",
         "node_modules/four/package.json",
@@ -255,7 +256,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/node_modules/sub-dep-one/index.js",
@@ -318,7 +319,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
@@ -381,7 +382,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.mjs" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
         "node_modules/nested-flattened-three/package.json",
@@ -422,7 +423,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "nested/path/hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "nested/path/hi.js" });
       expect(dependencies).to.eql(fullPath([
         "nested/node_modules/one/index.js",
         "nested/node_modules/one/package.json",
@@ -486,7 +487,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/four/index.js",
         "node_modules/four/package.json",
@@ -541,7 +542,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({
+      const { dependencies, misses } = await traceFile({
         srcPath: "hi.js",
         ignores: [
           "doesnt-exist",
@@ -556,7 +557,7 @@ describe("lib/trace", () => {
       ]));
     });
 
-    it("handles try/catch missing requires", async () => {
+    it("handles try/catch misses requires", async () => {
       mock({
         "hi.js": `
           require("one");
@@ -631,7 +632,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({
+      const { dependencies, misses } = await traceFile({
         srcPath: "hi.js",
         allowMissing: {
           "nested-trycatch-require": [
@@ -743,7 +744,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      const { dependencies, misses } = await traceFile({ srcPath: "hi.js" });
       expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.json",
         "node_modules/one/package.json",
@@ -766,7 +767,7 @@ describe("lib/trace", () => {
 
   describe("traceFiles", () => {
     it("handles empty sources list", async () => {
-      const { dependencies, missing } = await traceFiles({ srcPaths: [] });
+      const { dependencies, misses } = await traceFiles({ srcPaths: [] });
       expect(dependencies).to.eql([]);
     });
 
@@ -775,7 +776,7 @@ describe("lib/trace", () => {
         "hi.js": "module.exports = 'hi';"
       });
 
-      const { dependencies, missing } = await traceFiles({ srcPaths: ["hi.js"] });
+      const { dependencies, misses } = await traceFiles({ srcPaths: ["hi.js"] });
       expect(dependencies).to.eql([]);
     });
 
@@ -828,7 +829,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFiles({ srcPaths: [
+      const { dependencies, misses } = await traceFiles({ srcPaths: [
         "first.js",
         "second.js"
       ] });
@@ -897,7 +898,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFiles({ srcPaths: [
+      const { dependencies, misses } = await traceFiles({ srcPaths: [
         "first.mjs",
         "second.mjs"
       ] });
@@ -968,7 +969,7 @@ describe("lib/trace", () => {
         }
       });
 
-      const { dependencies, missing } = await traceFiles({ srcPaths: ["hi.js"] });
+      const { dependencies, misses } = await traceFiles({ srcPaths: ["hi.js"] });
       expect(dependencies).to.eql(fullPath([
         "ho.js",
         "node_modules/one/and-more/diff-path.js",

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -65,6 +65,9 @@ describe("lib/trace", () => {
 
           const variableResolve = "also-shouldnt-find";
           require.resolve(variableResolve);
+          require.resolve(\`interpolated_\${variableDep}\`);
+          require.resolve("binary" + "-expression");
+          require.resolve("binary" + variableDep);
         `,
         node_modules: {
           one: {
@@ -264,13 +267,17 @@ describe("lib/trace", () => {
       mock({
         "hi.js": `
           const one = require("one");
-          const dynamicTwo = () => import("two");
+          const dynamicTwo = () => import(\`two\`);
 
           (async () => {
             await import("three");
 
             const variableDep = "shouldnt-find";
             await import(variableDep);
+            await import(variableResolve);
+            await import(\`interpolated_\${variableDep}\`);
+            await import("binary" + "-expression");
+            await import("binary" + variableDep);
           })();
         `,
         node_modules: {

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -47,7 +47,8 @@ describe("lib/trace", () => {
         "hi.js": "module.exports = 'hi';"
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql([]);
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql([]);
     });
 
     it("handles requires with .js", async () => {
@@ -91,7 +92,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
         "node_modules/three/index.js",
@@ -137,7 +139,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.mjs" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.mjs",
         "node_modules/one/package.json",
         "node_modules/three/index.mjs",
@@ -191,7 +194,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.mjs" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/four/index.mjs",
         "node_modules/four/package.json",
         "node_modules/one/index.mjs",
@@ -251,7 +255,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/node_modules/sub-dep-one/index.js",
         "node_modules/one/node_modules/sub-dep-one/package.json",
@@ -313,7 +318,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
         "node_modules/three/index.mjs",
@@ -375,7 +381,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.mjs" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.mjs" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
         "node_modules/nested-flattened-three/package.json",
         "node_modules/one/index.mjs",
@@ -415,7 +422,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "nested/path/hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "nested/path/hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "nested/node_modules/one/index.js",
         "nested/node_modules/one/package.json",
         "node_modules/two/index.js",
@@ -478,7 +486,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/four/index.js",
         "node_modules/four/package.json",
         "node_modules/one/index.js",
@@ -532,13 +541,14 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({
+      const { dependencies, missing } = await traceFile({
         srcPath: "hi.js",
         ignores: [
           "doesnt-exist",
           "does-exist-shouldnt-import"
         ]
-      })).to.eql(fullPath([
+      });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
         "node_modules/two/index.js",
@@ -621,7 +631,7 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({
+      const { dependencies, missing } = await traceFile({
         srcPath: "hi.js",
         allowMissing: {
           "nested-trycatch-require": [
@@ -631,7 +641,8 @@ describe("lib/trace", () => {
             "also-doesnt-exist"
           ]
         }
-      })).to.eql(fullPath([
+      });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/nested-first-level/lib/index.js",
         "node_modules/nested-first-level/package.json",
         "node_modules/nested-trycatch-require/index.js",
@@ -732,7 +743,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFile({ srcPath: "hi.js" })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFile({ srcPath: "hi.js" });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.json",
         "node_modules/one/package.json",
         "node_modules/three/index.js",
@@ -754,7 +766,8 @@ describe("lib/trace", () => {
 
   describe("traceFiles", () => {
     it("handles empty sources list", async () => {
-      expect(await traceFiles({ srcPaths: [] })).to.eql([]);
+      const { dependencies, missing } = await traceFiles({ srcPaths: [] });
+      expect(dependencies).to.eql([]);
     });
 
     it("handles no dependencies", async () => {
@@ -762,7 +775,8 @@ describe("lib/trace", () => {
         "hi.js": "module.exports = 'hi';"
       });
 
-      expect(await traceFiles({ srcPaths: ["hi.js"] })).to.eql([]);
+      const { dependencies, missing } = await traceFiles({ srcPaths: ["hi.js"] });
+      expect(dependencies).to.eql([]);
     });
 
     it("handles dynamic imports with .js", async () => {
@@ -814,10 +828,11 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFiles({ srcPaths: [
+      const { dependencies, missing } = await traceFiles({ srcPaths: [
         "first.js",
         "second.js"
-      ] })).to.eql(fullPath([
+      ] });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/one/index.js",
         "node_modules/one/package.json",
         "node_modules/three/index.mjs",
@@ -882,10 +897,11 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFiles({ srcPaths: [
+      const { dependencies, missing } = await traceFiles({ srcPaths: [
         "first.mjs",
         "second.mjs"
-      ] })).to.eql(fullPath([
+      ] });
+      expect(dependencies).to.eql(fullPath([
         "node_modules/nested-flattened-three/index.mjs",
         "node_modules/nested-flattened-three/package.json",
         "node_modules/one/index.mjs",
@@ -952,7 +968,8 @@ describe("lib/trace", () => {
         }
       });
 
-      expect(await traceFiles({ srcPaths: ["hi.js"] })).to.eql(fullPath([
+      const { dependencies, missing } = await traceFiles({ srcPaths: ["hi.js"] });
+      expect(dependencies).to.eql(fullPath([
         "ho.js",
         "node_modules/one/and-more/diff-path.js",
         "node_modules/one/and-more/package.json",

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -16,16 +16,6 @@ const resolveObjKeys = (obj) => Object.entries(obj)
   .map(([key, val]) => [path.resolve(key), val])
   .reduce((memo, [key, val]) => ({ ...memo, [key]: val }), {});
 
-// Convert misses to single file source.
-const missesSrcs = ({ misses, srcPath }) => {
-  const srcFullPath = path.resolve(srcPath);
-  expect(misses).has.property(srcFullPath).that.is.an("array");
-  expect(Object.keys(misses)).to.have.length(1);
-  expect(misses[srcFullPath][0]).to.have.keys("start", "end", "loc", "src");
-
-  return misses[srcFullPath].map(({ src }) => src);
-};
-
 // Convert to map of sources.
 const missesMap = ({ misses }) => Object.entries(misses)
   .map(([key, objs]) => {
@@ -134,16 +124,18 @@ describe("lib/trace", () => {
         "node_modules/two/package.json"
       ]));
 
-      expect(missesSrcs({ misses, srcPath })).to.eql([
-        "require(variableDep)",
-        "require(`interpolated_${variableDep}`)",
-        "require(\"binary\" + \"-expression\")",
-        "require(\"binary\" + variableDep)",
-        "require.resolve(variableResolve)",
-        "require.resolve(`interpolated_${variableResolve}`)",
-        "require.resolve(\"binary\" + \"-expression\")",
-        "require.resolve(\"binary\" + variableResolve)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        [srcPath]: [
+          "require(variableDep)",
+          "require(`interpolated_${variableDep}`)",
+          "require(\"binary\" + \"-expression\")",
+          "require(\"binary\" + variableDep)",
+          "require.resolve(variableResolve)",
+          "require.resolve(`interpolated_${variableResolve}`)",
+          "require.resolve(\"binary\" + \"-expression\")",
+          "require.resolve(\"binary\" + variableResolve)"
+        ]
+      }));
     });
 
     it("handles imports with .mjs", async () => {
@@ -375,13 +367,15 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
-      expect(missesSrcs({ misses, srcPath })).to.eql([
-        "import(variableDep)",
-        "import(variableResolve)",
-        "import(`interpolated_${variableDep}`)",
-        "import(\"binary\" + \"-expression\")",
-        "import(\"binary\" + variableDep)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        [srcPath]: [
+          "import(variableDep)",
+          "import(variableResolve)",
+          "import(`interpolated_${variableDep}`)",
+          "import(\"binary\" + \"-expression\")",
+          "import(\"binary\" + variableDep)"
+        ]
+      }));
     });
 
     it("handles dynamic imports with .mjs", async () => {
@@ -446,9 +440,11 @@ describe("lib/trace", () => {
         "node_modules/two/index.mjs",
         "node_modules/two/package.json"
       ]));
-      expect(missesSrcs({ misses, srcPath })).to.eql([
-        "import(variableDep)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        [srcPath]: [
+          "import(variableDep)"
+        ]
+      }));
     });
 
     it("handles lower directories than where file is located", async () => {
@@ -988,9 +984,11 @@ describe("lib/trace", () => {
         "node_modules/two/index.js",
         "node_modules/two/package.json"
       ]));
-      expect(missesSrcs({ misses, srcPath: "second.js" })).to.eql([
-        "import(variableDep)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        "second.js": [
+          "import(variableDep)"
+        ]
+      }));
     });
 
     it("handles dynamic imports with .mjs", async () => {
@@ -1060,9 +1058,11 @@ describe("lib/trace", () => {
         "node_modules/two/index.mjs",
         "node_modules/two/package.json"
       ]));
-      expect(missesSrcs({ misses, srcPath: "second.mjs" })).to.eql([
-        "import(variableDep)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        "second.mjs": [
+          "import(variableDep)"
+        ]
+      }));
     });
 
     it("handles requires with arguments and local libs", async () => {
@@ -1133,9 +1133,11 @@ describe("lib/trace", () => {
         "node_modules/two/package.json",
         "package.json"
       ]));
-      expect(missesSrcs({ misses, srcPath: "ho.js" })).to.eql([
-        "require(variableDep)"
-      ]);
+      expect(missesMap({ misses })).to.eql(resolveObjKeys({
+        "ho.js": [
+          "require(variableDep)"
+        ]
+      }));
     });
 
     it("reports on complex, nested misses"); // TODO


### PR DESCRIPTION
* (**BREAKING**) Feature: Change `traceFile|traceFiles` signature to `{ dependencies, misses }` and report imports that cannot be traced. Fixes #25
* Feature: Add inference for template literal strings in imports.

/cc @pdeona @mscottx88 