### PR TITLE
Bug: Handle non-standard JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes
 
 ## UNRELEASED
 
-* Bug: Handle code with `Identifier 'NAME' has already been declared` parse errors.
+* Feature/Bug: More permissively parse JS code using `module` Acorn type first, with fallback to `script`.
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Bug: Handle code with `Identifier 'NAME' has already been declared` parse errors.
+
 ## 0.3.1
 
 * Chore: Minor internal refactor.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -109,7 +109,22 @@ const traceFile = async ({
   };
 
   // Parse and extract.
-  const ast = parse(src, { sourceType: "module", locations: true });
+  //
+  // Rather than trying to infer if a given source file is ESM vs. CJS, we just
+  // try both...
+  let ast;
+  try {
+    // First try as a module.
+    ast = parse(src, { sourceType: "module", locations: true });
+  } catch (modErr) {
+    // Then as script.
+    try {
+      ast = parse(src, { sourceType: "script", locations: true });
+    } catch (scriptErr) {
+      // Use original module error.
+      throw modErr;
+    }
+  }
   const { dependencies, misses } = getDeps({ ast, src });
 
   // Merge in misses.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -121,8 +121,8 @@ const traceFile = async ({
     try {
       ast = parse(src, { sourceType: "script", locations: true });
     } catch (scriptErr) {
-      // Use original module error.
-      throw modErr;
+      // Use original module error, with some helper errors.
+      throw new Error(`Encountered parse error in ${srcPath}: ${modErr}`);
     }
   }
   const { dependencies, misses } = getDeps({ ast, src });

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -908,6 +908,37 @@ describe("lib/trace", () => {
         ]
       }));
     });
+
+    it("handles already declared identifier code", async () => {
+      mock({
+        "hi.js": `
+          var foo = foo;
+
+          function foo() { return "Wow, this is valid!"; }
+
+          require("one");
+        `,
+        node_modules: {
+          one: {
+            "package.json": stringify({
+              main: "index.js"
+            }),
+            "index.js": `
+              module.exports = 'one';
+            `
+          }
+        }
+      });
+
+      const srcPath = "hi.js";
+      const { dependencies, misses } = await traceFile({ srcPath });
+      expect(dependencies).to.eql(fullPath([
+        "node_modules/one/index.js",
+        "node_modules/one/package.json"
+      ]));
+
+      expect(missesMap({ misses })).to.be.eql({});
+    });
   });
 
   describe("traceFiles", () => {

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -909,6 +909,19 @@ describe("lib/trace", () => {
       }));
     });
 
+    it("errors on syntax errors", async () => {
+      mock({
+        "hi.js": `
+          UN;&!PARSEABLE
+        `
+      });
+
+      const srcPath = "hi.js";
+      await expect(traceFile({ srcPath })).to.be.rejectedWith(
+        /Encountered parse error in .* SyntaxError: Unexpected token/
+      );
+    });
+
     it("handles already declared identifier code", async () => {
       mock({
         "hi.js": `


### PR DESCRIPTION
- Parse JS in both module / script modes.
- Add enhanced errors for parse errors.

/cc @pdeona @mscottx88 