### PR TITLE
Feature: Add `extraImports` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Add `extraImports` parameter to `traceFile`/`traceFiles`.
+
 ## 0.3.2
 
 * Feature/Bug: More permissively parse JS code using `module` Acorn type first, with fallback to `script`.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Parameters_:
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
 * `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
   missing module prefixes.
+* `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace. Key is in the form either a (1) absolute path to a source file (e.g., `/PATH/TO/src/foo.js`) or (2) relative path to a file from a package in `node_modules` starting at the package name (e.g. `lodash/index.js`). Value is an array of additional import specifiers that are resolved and further traced. The additional imports are anything that could be validly passed to a `require()` or `import` call.
 
 _Returns_:
 
@@ -56,6 +57,7 @@ _Parameters_:
 * `ignores` (`Array<string>`): list of package prefixes to ignore
 * `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
   missing module prefixes.
+  * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
 
 _Returns_:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ _Parameters_:
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
 * `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
   missing module prefixes.
-* `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace. Key is in the form either a (1) absolute path to a source file (e.g., `/PATH/TO/src/foo.js`) or (2) relative path to a file from a package in `node_modules` starting at the package name (e.g. `lodash/index.js`). Value is an array of additional import specifiers that are resolved and further traced. The additional imports are anything that could be validly passed to a `require()` or `import` call.
+* `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
+    * The **key** is in the form of either:
+        1. an **absolute** path to a source file (e.g., `/PATH/TO/src/foo.js`), or;
+        2. a **relative** path to a file from a package in `node_modules` starting at the package name (e.g. `lodash/index.js`).
+    * The **value** is an array of additional import specifiers that are resolved and further traced. The additional imports are anything that could be validly passed to a `require()` or `import` call (e.g., `./relative/path/to/source-file.js`, `a-pkg`, `a-pkg/with/nested/path.js`).
 
 _Returns_:
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ _Parameters_:
 * `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
   missing module prefixes.
 * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
-    * The **key** is in the form of either:
+    * The **key** is path (either Posix or native OS paths are accepted) in the form of either:
         1. an **absolute** path to a source file (e.g., `/PATH/TO/src/foo.js`), or;
         2. a **relative** path to a file from a package in `node_modules` starting at the package name (e.g. `lodash/index.js`).
     * The **value** is an array of additional import specifiers that are resolved and further traced. The additional imports are anything that could be validly passed to a `require()` or `import` call (e.g., `./relative/path/to/source-file.js`, `a-pkg`, `a-pkg/with/nested/path.js`).
+        * Paths should be specified as you would in a Node.js `require()` which is to say Posix `/` form.
 
 _Returns_:
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ _Parameters_:
 
 * `srcPath` (`string`): source file path to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
-  missing module prefixes.
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted missing module prefixes.
 * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
     * The **key** is path (either Posix or native OS paths are accepted) in the form of either:
         1. an **absolute** path to a source file (e.g., `/PATH/TO/src/foo.js`), or;
@@ -60,9 +59,8 @@ _Parameters_:
 
 * `srcPaths` (`Array<string>`): source file paths to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted
-  missing module prefixes.
-  * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted missing module prefixes.
+* `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
 
 _Returns_:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
     - nodejs_version: "10"
     - nodejs_version: "12"
-    - nodejs_version: "13" # TODO(CI): Update to 14 once AppVeyor has package.
+    - nodejs_version: "14"
 
 branches:
   only:

--- a/lib/package.js
+++ b/lib/package.js
@@ -33,7 +33,26 @@ const getPackages = (filePath) => {
 // Return last (deepest) package in a file path.
 const getLastPackage = (filePath) => getPackages(filePath).pop() || null;
 
+// Return the entire path after that last (deepest) package after `node_modules`
+const getLastPackageSegment = (filePath) => {
+  if (!filePath) { return null; }
+
+  // Iterate all normalized parts of the file path and extract packages.
+  const parts = path.normalize(filePath).split(path.sep);
+  const lastModsIdx = parts.lastIndexOf("node_modules");
+  // Not within node_modules.
+  if (lastModsIdx === -1) { return null; }
+
+  const relParts = parts.slice(lastModsIdx + 1);
+  // Not a valid starting package.
+  if (relParts.length === 0 || relParts.length === 1 && relParts[0][0] === "@") { return null; }
+
+  const relPath = relParts.join(path.sep);
+  return relPath || null;
+};
+
 module.exports = {
   getPackages,
-  getLastPackage
+  getLastPackage,
+  getLastPackageSegment
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -16,6 +16,7 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
   memo[key] = obj[key];
   return memo;
 }, {});
+const toPosixPath = (file) => !file ? file : path.normalize(file.replace(/\\/g, "/"));
 
 
 // The dependency file name matches a configuration package prefix.
@@ -24,22 +25,20 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
 // - match up to file separator
 const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.startsWith(`${pkg}/`);
 
-const findExtraImportsKey = (key, extraImports) =>
-  extraImports[path.posix.normalize(key)]
-  || extraImports[path.win32.normalize(key)];
+// Convert all keys to posix paths.
+const normalizeExtraImports = (extraImports) => Object.entries(extraImports)
+  .reduce((memo, [key, vals]) => {
+    memo[toPosixPath(key)] = vals;
+    return memo;
+  }, {});
 
 // Return any extra imports to add to the dependencies for a given source path.
-const getExtraImports = ({ srcPath, extraImports }) => {
+const getExtraImports = ({ srcPath, _extraImports }) => {
   if (!srcPath) { return new Set(); }
 
   // Application source match of full path.
   // Use either posix or win path for keys.
-  const fullMatch = findExtraImportsKey(srcPath, extraImports);
-  console.log("TODO HERE", { // eslint-disable-line no-console
-    srcPath,
-    fullMatch,
-    extraImports
-  });
+  const fullMatch = _extraImports[toPosixPath(srcPath)];
   if (fullMatch) {
     return new Set(fullMatch);
   }
@@ -48,12 +47,11 @@ const getExtraImports = ({ srcPath, extraImports }) => {
   // Use either native or Posix path for keys.
   const relPath = getLastPackageSegment(srcPath);
   if (relPath) {
-    const relMatch = findExtraImportsKey(relPath, extraImports);
+    const relMatch = _extraImports[toPosixPath(relPath)];
     if (relMatch) {
       return new Set(relMatch);
     }
   }
-
 
   // Empty set.
   return new Set();
@@ -67,7 +65,7 @@ const _recurseDeps = async ({
   depPaths = [],
   ignores = [],
   allowMissing = {},
-  extraImports = {},
+  _extraImports,
   _tracedDepPaths
 }) => {
   // Start **only** with depPaths.
@@ -91,7 +89,7 @@ const _recurseDeps = async ({
         srcPath: depPath,
         ignores,
         allowMissing,
-        extraImports,
+        _extraImports,
         _tracedDepPaths
       });
 
@@ -122,6 +120,7 @@ const _recurseDeps = async ({
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
  * @param {Object}        opts.extraImports     map files to additional imports to trace
+ * @param {Object}        opts._extraImports    (internal) normalized map
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
  * @returns {Promise<Object>}                   dependencies and other information
  */
@@ -131,11 +130,15 @@ const traceFile = async ({
   ignores = [],
   allowMissing = {},
   extraImports = {},
+  _extraImports,
   _tracedDepPaths = new Set()
 } = {}) => {
   if (!srcPath) {
     throw new Error("Empty source file path");
   }
+
+  // Parameters
+  _extraImports = _extraImports || normalizeExtraImports(extraImports);
 
   // Get source.
   const src = await readFile(srcPath)
@@ -171,7 +174,7 @@ const traceFile = async ({
   const { dependencies, misses } = getDeps({ ast, src });
 
   // Add in additional dependencies.
-  const extraDeps = getExtraImports({ srcPath, extraImports });
+  const extraDeps = getExtraImports({ srcPath, _extraImports });
   Array.from(extraDeps).forEach((dep) => { dependencies.add(dep); });
 
   // Merge in misses.
@@ -245,7 +248,7 @@ const traceFile = async ({
     depPaths,
     ignores,
     allowMissing,
-    extraImports,
+    _extraImports,
     _tracedDepPaths
   });
 
@@ -269,6 +272,7 @@ const traceFile = async ({
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
  * @param {Object}        opts.extraImports     map files to additional imports to trace
+ * @param {Object}        opts._extraImports    (internal) normalized map
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
  * @returns {Promise<Object>}                   dependencies and other information
  */
@@ -277,14 +281,17 @@ const traceFiles = async ({
   ignores = [],
   allowMissing = {},
   extraImports = {},
+  _extraImports,
   _tracedDepPaths = new Set()
 } = {}) => {
+  _extraImports = _extraImports || normalizeExtraImports(extraImports);
+
   // Recurse all source files.
   const results = await _recurseDeps({
     srcPaths,
     ignores,
     allowMissing,
-    extraImports,
+    _extraImports,
     _tracedDepPaths
   });
 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -24,14 +24,17 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
 // - match up to file separator
 const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.startsWith(`${pkg}/`);
 
+const findExtraImportsKey = (key, extraImports) =>
+  extraImports[path.posix.normalize(key)]
+  || extraImports[path.win32.normalize(key)];
+
 // Return any extra imports to add to the dependencies for a given source path.
 const getExtraImports = ({ srcPath, extraImports }) => {
   if (!srcPath) { return new Set(); }
 
   // Application source match of full path.
-  // Use either native or Posix path for keys.
-  const srcPathPosix = path.posix.normalize(srcPath);
-  const fullMatch = extraImports[srcPath] || extraImports[srcPathPosix];
+  // Use either posix or win path for keys.
+  const fullMatch = findExtraImportsKey(srcPath, extraImports);
   if (fullMatch) {
     return new Set(fullMatch);
   }
@@ -40,8 +43,7 @@ const getExtraImports = ({ srcPath, extraImports }) => {
   // Use either native or Posix path for keys.
   const relPath = getLastPackageSegment(srcPath);
   if (relPath) {
-    const relPathPosix = path.posix.normalize(relPath);
-    const relMatch = extraImports[relPath] || extraImports[relPathPosix];
+    const relMatch = findExtraImportsKey(relPath, extraImports);
     if (relMatch) {
       return new Set(relMatch);
     }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -18,7 +18,6 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
 }, {});
 const toPosixPath = (file) => !file ? file : path.normalize(file.replace(/\\/g, "/"));
 
-
 // The dependency file name matches a configuration package prefix.
 // Only allow:
 // - exact match

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -23,8 +23,9 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
 const _recurseDeps = async ({
   srcPaths,
   depPaths = [],
-  ignores,
-  allowMissing,
+  ignores = [],
+  allowMissing = {},
+  extraImports = {},
   _tracedDepPaths
 }) => {
   // Start **only** with depPaths.
@@ -44,9 +45,13 @@ const _recurseDeps = async ({
 
       // Recurse.
       // eslint-disable-next-line no-use-before-define
-      const traced = await traceFile(
-        { srcPath: depPath, ignores, allowMissing, _tracedDepPaths }
-      );
+      const traced = await traceFile({
+        srcPath: depPath,
+        ignores,
+        allowMissing,
+        extraImports,
+        _tracedDepPaths
+      });
 
       // Aggregate.
       misses = { ...misses, ...traced.misses };
@@ -80,6 +85,7 @@ const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.starts
  * @param {string}        opts.srcPath          source file path to trace
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
+ * @param {Object}        opts.extraImports     map files to additional imports to trace
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
  * @returns {Promise<Object>}                   dependencies and other information
  */
@@ -88,6 +94,7 @@ const traceFile = async ({
   srcPath,
   ignores = [],
   allowMissing = {},
+  extraImports = {},
   _tracedDepPaths = new Set()
 } = {}) => {
   if (!srcPath) {
@@ -194,7 +201,13 @@ const traceFile = async ({
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   _tracedDepPaths.add(srcPath);
-  const recursed = await _recurseDeps({ depPaths, ignores, allowMissing, _tracedDepPaths });
+  const recursed = await _recurseDeps({
+    depPaths,
+    ignores,
+    allowMissing,
+    extraImports,
+    _tracedDepPaths
+  });
 
   results.misses = sortObj({ ...results.misses, ...recursed.misses });
   results.dependencies = uniq([].concat(
@@ -215,6 +228,7 @@ const traceFile = async ({
  * @param {Array<string>} opts.srcPaths         source file paths to trace
  * @param {Array<string>} opts.ignores          list of package prefixes to ignore
  * @param {Object}        opts.allowMissing     map packages to list of allowed missing package
+ * @param {Object}        opts.extraImports     map files to additional imports to trace
  * @param {Set}           opts._tracedDepPaths  (internal) tracked dependencies
  * @returns {Promise<Object>}                   dependencies and other information
  */
@@ -222,10 +236,17 @@ const traceFiles = async ({
   srcPaths,
   ignores = [],
   allowMissing = {},
+  extraImports = {},
   _tracedDepPaths = new Set()
 } = {}) => {
   // Recurse all source files.
-  const results = await _recurseDeps({ srcPaths, ignores, allowMissing, _tracedDepPaths });
+  const results = await _recurseDeps({
+    srcPaths,
+    ignores,
+    allowMissing,
+    extraImports,
+    _tracedDepPaths
+  });
 
   // Make unique and return.
   return {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -33,8 +33,11 @@ const getExtraImports = ({ srcPath, extraImports }) => {
   }
 
   // Package match of relative prefix.
-  const relMatch = getLastPackageSegment(srcPath);
-  console.log("TODO HERE", { relMatch });
+  const relPath = getLastPackageSegment(srcPath);
+  const relMatch = extraImports[relPath];
+  if (relMatch) {
+    return new Set(relMatch);
+  }
 
   // Empty set.
   return new Set();
@@ -150,13 +153,10 @@ const traceFile = async ({
     }
   }
   const { dependencies, misses } = getDeps({ ast, src });
-  const extraDependencies = getExtraImports({ srcPath, extraImports });
-  console.log("TODO HERE getDeps", {
-    srcPath,
-    dependencies,
-    extraImports,
-    extraDependencies
-  });
+
+  // Add in additional dependencies.
+  const extraDeps = getExtraImports({ srcPath, extraImports });
+  Array.from(extraDeps).forEach((dep) => { dependencies.add(dep); });
 
   // Merge in misses.
   if (misses.length) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -6,7 +6,7 @@ const { promisify } = require("util");
 
 const { parse } = require("acorn-node");
 const { getDeps } = require("./extract");
-const { getLastPackage } = require("./package");
+const { getLastPackage, getLastPackageSegment } = require("./package");
 
 // Helpers
 const resolve = promisify(require("resolve"));
@@ -16,6 +16,29 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
   memo[key] = obj[key];
   return memo;
 }, {});
+
+
+// The dependency file name matches a configuration package prefix.
+// Only allow:
+// - exact match
+// - match up to file separator
+const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.startsWith(`${pkg}/`);
+
+// Return any extra imports to add to the dependencies for a given source path.
+const getExtraImports = ({ srcPath, extraImports }) => {
+  // Application source match of full path.
+  const fullMatch = extraImports[srcPath];
+  if (fullMatch) {
+    return new Set(fullMatch);
+  }
+
+  // Package match of relative prefix.
+  const relMatch = getLastPackageSegment(srcPath);
+  console.log("TODO HERE", { relMatch });
+
+  // Empty set.
+  return new Set();
+};
 
 // HELPER: Recursively track and trace dependency paths.
 // - `srcPaths`: If provided, **don't** add to resolvedDepPaths
@@ -64,12 +87,6 @@ const _recurseDeps = async ({
     misses
   };
 };
-
-// The dependency file name matches a configuration package prefix.
-// Only allow:
-// - exact match
-// - match up to file separator
-const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.startsWith(`${pkg}/`);
 
 /**
  * Trace and return on-disk locations of all file dependencies from a source file.
@@ -133,6 +150,13 @@ const traceFile = async ({
     }
   }
   const { dependencies, misses } = getDeps({ ast, src });
+  const extraDependencies = getExtraImports({ srcPath, extraImports });
+  console.log("TODO HERE getDeps", {
+    srcPath,
+    dependencies,
+    extraImports,
+    extraDependencies
+  });
 
   // Merge in misses.
   if (misses.length) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -35,6 +35,11 @@ const getExtraImports = ({ srcPath, extraImports }) => {
   // Application source match of full path.
   // Use either posix or win path for keys.
   const fullMatch = findExtraImportsKey(srcPath, extraImports);
+  console.log("TODO HERE", { // eslint-disable-line no-console
+    srcPath,
+    fullMatch,
+    extraImports
+  });
   if (fullMatch) {
     return new Set(fullMatch);
   }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -26,18 +26,27 @@ const matchesPkgPrefix = (depName) => (pkg) => depName === pkg || depName.starts
 
 // Return any extra imports to add to the dependencies for a given source path.
 const getExtraImports = ({ srcPath, extraImports }) => {
+  if (!srcPath) { return new Set(); }
+
   // Application source match of full path.
-  const fullMatch = extraImports[srcPath];
+  // Use either native or Posix path for keys.
+  const srcPathPosix = path.posix.normalize(srcPath);
+  const fullMatch = extraImports[srcPath] || extraImports[srcPathPosix];
   if (fullMatch) {
     return new Set(fullMatch);
   }
 
   // Package match of relative prefix.
+  // Use either native or Posix path for keys.
   const relPath = getLastPackageSegment(srcPath);
-  const relMatch = extraImports[relPath];
-  if (relMatch) {
-    return new Set(relMatch);
+  if (relPath) {
+    const relPathPosix = path.posix.normalize(relPath);
+    const relMatch = extraImports[relPath] || extraImports[relPathPosix];
+    if (relMatch) {
+      return new Set(relMatch);
+    }
   }
+
 
   // Empty set.
   return new Set();

--- a/test/lib/package.spec.js
+++ b/test/lib/package.spec.js
@@ -78,19 +78,19 @@ describe("lib/package", () => {
     it("handles single modules", () => {
       expect(getLastPackageSegment(normalize("node_modules/bar"))).to.eql("bar");
       expect(getLastPackageSegment(normalize("node_modules/bar/src/foo.js")))
-        .to.eql("bar/src/foo.js");
+        .to.eql(normalize("bar/src/foo.js"));
       expect(getLastPackageSegment(normalize("path/to/node_modules/@scope/foo")))
-        .to.eql("@scope/foo");
+        .to.eql(normalize("@scope/foo"));
       expect(getLastPackageSegment(normalize("path/to/node_modules/@scope/foo/index.js")))
-        .to.eql("@scope/foo/index.js");
+        .to.eql(normalize("@scope/foo/index.js"));
     });
 
     it("handles nested modules", () => {
       expect(getLastPackageSegment(normalize("node_modules/bar/node_modules/@scope/nested-bar")))
-        .to.eql("@scope/nested-bar");
+        .to.eql(normalize("@scope/nested-bar"));
       expect(getLastPackageSegment(
         normalize("node_modules/bar/node_modules/@scope/nested-bar/path/to/nested.js")
-      )).to.eql("@scope/nested-bar/path/to/nested.js");
+      )).to.eql(normalize("@scope/nested-bar/path/to/nested.js"));
     });
   });
 });

--- a/test/lib/package.spec.js
+++ b/test/lib/package.spec.js
@@ -2,7 +2,7 @@
 
 const { normalize } = require("path");
 
-const { getPackages, getLastPackage } = require("../../lib/package");
+const { getPackages, getLastPackage, getLastPackageSegment } = require("../../lib/package");
 
 describe("lib/package", () => {
   describe("getPackages", () => {
@@ -46,7 +46,6 @@ describe("lib/package", () => {
       expect(getLastPackage(normalize("path/to/node_modules/@scope"))).to.eql(null);
     });
 
-
     it("handles single modules", () => {
       expect(getLastPackage(normalize("node_modules/bar"))).to.eql("bar");
       expect(getLastPackage(normalize("path/to/node_modules/@scope/foo"))).to.eql("@scope/foo");
@@ -59,6 +58,39 @@ describe("lib/package", () => {
         "path/to/node_modules/@scope/foo/node_modules/three/node_modules/four/node_modules"
       )))
         .to.eql("four");
+    });
+  });
+
+  describe("getLastPackageSegment", () => {
+    it("handles empty input", () => {
+      expect(getLastPackageSegment()).to.eql(null);
+      expect(getLastPackageSegment(null)).to.eql(null);
+    });
+
+    it("handles no modules", () => {
+      expect(getLastPackageSegment(normalize(""))).to.eql(null);
+      expect(getLastPackageSegment(normalize("src"))).to.eql(null);
+      expect(getLastPackageSegment(normalize("src/nested/path.js"))).to.eql(null);
+      expect(getLastPackageSegment(normalize("path/to/node_modules"))).to.eql(null);
+      expect(getLastPackageSegment(normalize("path/to/node_modules/@scope"))).to.eql(null);
+    });
+
+    it("handles single modules", () => {
+      expect(getLastPackageSegment(normalize("node_modules/bar"))).to.eql("bar");
+      expect(getLastPackageSegment(normalize("node_modules/bar/src/foo.js")))
+        .to.eql("bar/src/foo.js");
+      expect(getLastPackageSegment(normalize("path/to/node_modules/@scope/foo")))
+        .to.eql("@scope/foo");
+      expect(getLastPackageSegment(normalize("path/to/node_modules/@scope/foo/index.js")))
+        .to.eql("@scope/foo/index.js");
+    });
+
+    it("handles nested modules", () => {
+      expect(getLastPackageSegment(normalize("node_modules/bar/node_modules/@scope/nested-bar")))
+        .to.eql("@scope/nested-bar");
+      expect(getLastPackageSegment(
+        normalize("node_modules/bar/node_modules/@scope/nested-bar/path/to/nested.js")
+      )).to.eql("@scope/nested-bar/path/to/nested.js");
     });
   });
 });

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1046,12 +1046,12 @@ describe("lib/trace", () => {
         extraImports: {
           // Absolute path, so application source file with **full match**
           // Use win32 path.
-          [path.win32.resolve("./lib/middle/ho.js")]: [
+          [path.resolve(".\\lib\\middle\\ho.js")]: [
             "../extra/file",
             "extra-pkg-app/nested/path"
           ],
           // Use posix path.
-          [path.posix.resolve("./lib/middle/how.js")]: [
+          [path.resolve("./lib/middle/how.js")]: [
             "../extra/file2"
           ],
           // Package, so relative match after _last_ `node_modules`.

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1039,8 +1039,8 @@ describe("lib/trace", () => {
         extraImports: {
           // Absolute path, so application source file with **full match**
           [path.resolve("./lib/middle/ho.js")]: [
-            "../extra/file.js",
-            "extra-pkg-app/nested/path.js"
+            "../extra/file",
+            "extra-pkg-app/nested/path"
           ],
           // Package, so relative match after _last_ `node_modules`.
           "one/lib/nested/deeper-one.js": [

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1002,7 +1002,7 @@ describe("lib/trace", () => {
               };
             `
           },
-          "extra-package-app": {
+          "extra-pkg-app": {
             "package.json": stringify({
               main: "index.js"
             }),
@@ -1015,12 +1015,20 @@ describe("lib/trace", () => {
               `
             }
           },
-          "extra-package-one": {
+          "extra-pkg-one": {
             "package.json": stringify({
               main: "index.js"
             }),
             "index.js": `
               module.exports = "Directly imported via extraImports";
+            `
+          },
+          "extra-pkg-from-extra-import": {
+            "package.json": stringify({
+              main: "index.js"
+            }),
+            "index.js": `
+              module.exports = "An extraImports bring this one in!";
             `
           }
         }
@@ -1031,22 +1039,27 @@ describe("lib/trace", () => {
         extraImports: {
           // Absolute path, so application source file with **full match**
           [path.resolve("./lib/middle/ho.js")]: [
-            "lib/extra/file.js",
+            "../extra/file.js",
             "extra-pkg-app/nested/path.js"
           ],
           // Package, so relative match after _last_ `node_modules`.
           "one/lib/nested/deeper-one.js": [
             "extra-pkg-one"
+          ],
+          // Package from the **above** extra import! Should also get traversed
+          // same as the other ones...
+          "extra-pkg-one/index.js": [
+            "extra-pkg-from-extra-import"
           ]
-          // TODO: ADD AND TEST
-          // TODO: **another** extraImport for something added by extra import?
-          //       Like a nested path in `extra-pkg-one` + a bare package name.
         }
       });
       expect(dependencies).to.eql(fullPath([
-        "lib/middle/ho.js",
         "lib/extra/file.js",
+        "lib/middle/ho.js",
         "node_modules/extra-pkg-app/nested/path.js",
+        "node_modules/extra-pkg-app/package.json",
+        "node_modules/extra-pkg-from-extra-import/index.js",
+        "node_modules/extra-pkg-from-extra-import/package.json",
         "node_modules/extra-pkg-one/index.js",
         "node_modules/extra-pkg-one/package.json",
         "node_modules/one/index.js",

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -957,11 +957,15 @@ describe("lib/trace", () => {
       mock({
         "hi.js": `
           require("./lib/middle/ho");
+          require("./lib/middle/how");
           require("one");
         `,
         lib: {
           middle: {
             "ho.js": `
+              module.exports = "No actual missing imports";
+            `,
+            "how.js": `
               module.exports = "No actual missing imports";
             `
           },
@@ -1038,9 +1042,14 @@ describe("lib/trace", () => {
         srcPath: "hi.js",
         extraImports: {
           // Absolute path, so application source file with **full match**
+          // Use native path.
           [path.resolve("./lib/middle/ho.js")]: [
             "../extra/file",
             "extra-pkg-app/nested/path"
+          ],
+          // Use posix path.
+          "./lib/middle/how.js": [
+            "../extra/file2"
           ],
           // Package, so relative match after _last_ `node_modules`.
           "one/lib/nested/deeper-one.js": [
@@ -1056,6 +1065,7 @@ describe("lib/trace", () => {
       expect(dependencies).to.eql(fullPath([
         "lib/extra/file.js",
         "lib/middle/ho.js",
+        "lib/middle/how.js",
         "node_modules/extra-pkg-app/nested/path.js",
         "node_modules/extra-pkg-app/package.json",
         "node_modules/extra-pkg-from-extra-import/index.js",

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -972,6 +972,9 @@ describe("lib/trace", () => {
           extra: {
             "file.js": `
               module.exports = "Not imported directly";
+            `,
+            "file2.js": `
+              module.exports = "Not imported directly";
             `
           }
         },
@@ -1042,13 +1045,13 @@ describe("lib/trace", () => {
         srcPath: "hi.js",
         extraImports: {
           // Absolute path, so application source file with **full match**
-          // Use native path.
-          [path.resolve("./lib/middle/ho.js")]: [
+          // Use win32 path.
+          [path.win32.resolve("./lib/middle/ho.js")]: [
             "../extra/file",
             "extra-pkg-app/nested/path"
           ],
           // Use posix path.
-          "./lib/middle/how.js": [
+          [path.posix.resolve("./lib/middle/how.js")]: [
             "../extra/file2"
           ],
           // Package, so relative match after _last_ `node_modules`.
@@ -1064,6 +1067,7 @@ describe("lib/trace", () => {
       });
       expect(dependencies).to.eql(fullPath([
         "lib/extra/file.js",
+        "lib/extra/file2.js",
         "lib/middle/ho.js",
         "lib/middle/how.js",
         "node_modules/extra-pkg-app/nested/path.js",


### PR DESCRIPTION
* Feature: Add `extraImports` parameter to `traceFile`/`traceFiles`.
* Replace node13 with node14 on AppVeyor CI

(To support `trace.dynamic.resolutions` in https://github.com/FormidableLabs/serverless-jetpack/issues/114 )