### PR TITLE
Feature: Allow source paths in `allowMissing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Support application source paths in `allowMissing` configuration.
+  [#41](https://github.com/FormidableLabs/trace-deps/issues/41)
+
 ## 0.3.7
 
 * Bug: Fix `allowMissing` when used with Node.js built-in modules.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _Parameters_:
 
 * `srcPath` (`string`): source file path to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted missing module prefixes.
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) source file paths and (2) package prefixes to permitted missing module prefixes. Source file paths must match the entire file path (resolved to CWD if relative) (`./entry.js` is matched as `/FULL/PATH/TO/entry.js`) while package prefixes are the start of package name and optionally more of the path (`lodash` or `@scope/pkg/some/path`).
 * `bailOnMissing` (`boolean`): Throw error if missing static import. (Default: `true`). If false, misses are added to `misses` object.
 * `includeSourceMaps` (`boolean`): Include source map resolved file paths from control comments. File paths are not actually checked to see if present.  (Default: `false`)
     * Source mapping URLs are only included and resolved if they are of the form `//# sourceMappingURL=<url>` or `//@ sourceMappingURL=<url>` and have a relative / absolute on-disk path (that is resolved relative to source file containing the comment). URL values starting with `http://` or `https://` are ignored.
@@ -67,7 +67,7 @@ _Parameters_:
 
 * `srcPaths` (`Array<string>`): source file paths to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of package prefixes to permitted missing module prefixes.
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of source file paths and package prefixes to permitted missing module prefixes.
 * `bailOnMissing` (`boolean`): Throw error if missing static import.
 * `includeSourceMaps` (`boolean`): Include source map file paths from control comments
 * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.
@@ -114,6 +114,18 @@ Examples:
     traceFile({
       srcPath,
       allowMissing: {
+        // While we don't normally expect your _own_ application sources to
+        // have tracing misses, this often comes up in transpiled output that
+        // you don't full control like Next.js `target: "serverless"` webpack
+        // bundles for Lambda handlers.
+        "./dist/my-app.js":[
+          "critters"
+        ],
+        "/FULL/PATH/WORKS/TOO/dist/my-app.js":[
+          "critters"
+        ],
+        // A normal package name from `node_modules`. The `ws` library for
+        // example has various optional `require()`s.
         "ws": [
           // See, e.g.: https://github.com/websockets/ws/blob/08c6c8ba70404818f7f4bc23eb5fd0bf9c94c039/lib/buffer-util.js#L121-L122
           "bufferutil",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _Parameters_:
 
 * `srcPath` (`string`): source file path to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) source file paths and (2) package prefixes to permitted missing module prefixes. Source file paths must match the entire file path (resolved to CWD if relative) (`./entry.js` is matched as `/FULL/PATH/TO/entry.js`) while package prefixes are the start of package name and optionally more of the path (`lodash` or `@scope/pkg/some/path`).
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) absolute source file paths and (2) package prefixes to permitted missing module prefixes. Source file paths must match the entire file path (e.g., `/FULL/PATH/TO/entry.js`) while package prefixes are the start of package name and optionally more of the path (e.g., `lodash` or `@scope/pkg/some/path`).
 * `bailOnMissing` (`boolean`): Throw error if missing static import. (Default: `true`). If false, misses are added to `misses` object.
 * `includeSourceMaps` (`boolean`): Include source map resolved file paths from control comments. File paths are not actually checked to see if present.  (Default: `false`)
     * Source mapping URLs are only included and resolved if they are of the form `//# sourceMappingURL=<url>` or `//@ sourceMappingURL=<url>` and have a relative / absolute on-disk path (that is resolved relative to source file containing the comment). URL values starting with `http://` or `https://` are ignored.
@@ -118,10 +118,7 @@ Examples:
         // have tracing misses, this often comes up in transpiled output that
         // you don't full control like Next.js `target: "serverless"` webpack
         // bundles for Lambda handlers.
-        "./dist/my-app.js":[
-          "critters"
-        ],
-        "/FULL/PATH/WORKS/TOO/dist/my-app.js":[
+        "/FULL/PATH/TO/dist/my-app.js":[
           "critters"
         ],
         // A normal package name from `node_modules`. The `ws` library for

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -63,6 +63,21 @@ const getExtraImports = ({ srcPath, _extraImports }) => {
   return new Set();
 };
 
+const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
+  // Try full source path match first.
+  let allowed = allowMissing[path.resolve(srcPath)];
+
+  // Then try package name.
+  if (!allowed) {
+    const srcPkg = getLastPackage(srcPath);
+    if (srcPkg) {
+      allowed = allowMissing[srcPkg];
+    }
+  }
+
+  return allowed && allowed.some(matchesPkgPrefix(depName));
+};
+
 // HELPER: Recursively track and trace dependency paths.
 // - `srcPaths`: If provided, **don't** add to resolvedDepPaths
 // - `depPaths`: If provided, **do** add to resolvedDepPaths
@@ -250,10 +265,7 @@ const traceFile = async ({
           // Handle module not found.
           if (err.code === "MODULE_NOT_FOUND") {
             // If allowed, then add to depObjs anyway.
-            const srcPkg = getLastPackage(srcPath);
-            const isAllowed = srcPkg && (allowMissing[srcPkg] || [])
-              .some(matchesPkgPrefix(depName));
-            if (isAllowed) {
+            if (isAllowedMiss({ depName, srcPath, allowMissing })) {
               return { depPath: depName, pkgPaths: [] };
             }
 

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1077,7 +1077,6 @@ describe("lib/trace", () => {
       expect(misses).to.eql({});
     });
 
-
     it("handles missing package.json:main and index.json", async () => {
       mock({
         "hi.js": `

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1015,6 +1015,69 @@ describe("lib/trace", () => {
       );
     });
 
+    it("handles misses in entry point app source", async () => {
+      mock({
+        "entry.js": `
+          require("missing-pkg");
+        `
+      });
+
+      const { dependencies, misses } = await traceFile({
+        srcPath: "entry.js",
+        allowMissing: {
+          [path.resolve("entry.js")]: [
+            "missing-pkg"
+          ]
+        }
+      });
+      expect(dependencies).to.eql(fullPaths([]));
+      expect(misses).to.eql({});
+    });
+
+    it("handles misses in full path entry point app source", async () => {
+      mock({
+        "entry.js": `
+          require("missing-pkg");
+        `
+      });
+
+      const { dependencies, misses } = await traceFile({
+        srcPath: path.resolve("entry.js"),
+        allowMissing: {
+          [path.resolve("entry.js")]: [
+            "missing-pkg"
+          ]
+        }
+      });
+      expect(dependencies).to.eql(fullPaths([]));
+      expect(misses).to.eql({});
+    });
+
+    it("handles misses in nested app source", async () => {
+      mock({
+        "entry.js": `
+          require("./nested");
+        `,
+        "nested.js": `
+          module.exports = require("missing-pkg");
+        `
+      });
+
+      const { dependencies, misses } = await traceFile({
+        srcPath: "entry.js",
+        allowMissing: {
+          [path.resolve("entry.js")]: [
+            "missing-pkg"
+          ]
+        }
+      });
+      expect(dependencies).to.eql(fullPaths([
+        "nested.js"
+      ]));
+      expect(misses).to.eql({});
+    });
+
+
     it("handles missing package.json:main and index.json", async () => {
       mock({
         "hi.js": `

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1066,7 +1066,7 @@ describe("lib/trace", () => {
       const { dependencies, misses } = await traceFile({
         srcPath: "entry.js",
         allowMissing: {
-          [path.resolve("entry.js")]: [
+          [path.resolve("nested.js")]: [
             "missing-pkg"
           ]
         }


### PR DESCRIPTION
- Support application source paths in `allowMissing` configuration. Fixes #41 