### PR TITLE
Chore: CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -13,25 +19,25 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
-    # Setup
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    # Installation
-    - run: yarn --version
-    - run: yarn install --frozen-lockfile
-      env:
-        CI: true
+      - name: Installation
+        run: yarn install --frozen-lockfile --non-interactive
+        env:
+          CI: true
 
-    # Basic script runs
-    - run: node bin/trace-deps.js -v
-    - run: node bin/trace-deps.js -h
+      - name: Basic script runs
+        run: |
+          node bin/trace-deps.js -v
+          node bin/trace-deps.js -h
 
-    # CI
-    - run: yarn check-ci
-    - run: yarn codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Checks
+        run: yarn check-ci
+      - name: Code coverage
+        run: yarn codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -141,5 +141,5 @@ Examples:
 [npm_site]: http://badge.fury.io/js/trace-deps
 [actions_img]: https://github.com/FormidableLabs/trace-deps/workflows/CI/badge.svg
 [actions_site]: https://github.com/FormidableLabs/trace-deps/actions
-[cov_img]: https://codecov.io/gh/FormidableLabs/trace-deps/branch/master/graph/badge.svg
+[cov_img]: https://codecov.io/gh/FormidableLabs/trace-deps/branch/main/graph/badge.svg
 [cov_site]: https://codecov.io/gh/FormidableLabs/trace-deps


### PR DESCRIPTION
- Update CI names and run only on main branch
- Update badges internal links now that we've renamed default branch