### PR TITLE
Feature: allow missing pkg paths as relative file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: REINSTATE
-        # os: [ubuntu-latest, windows-latest]
-        # node-version: [10.x, 12.x, 14.x, 15.x]
-        os: [windows-latest]
-        node-version: [14.x]
+        os: [ubuntu-latest, windows-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        # TODO: REINSTATE
+        # os: [ubuntu-latest, windows-latest]
+        # node-version: [10.x, 12.x, 14.x, 15.x]
+        os: [windows-latest]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Bug/Feature: Support relative paths from package name root in `allowMissing`.
+  [#49](https://github.com/FormidableLabs/trace-deps/issues/49)
+
 ## 0.3.8
 
 * Feature: Support application source paths in `allowMissing` configuration.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Parameters_:
 * `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) absolute source file paths and (2) package name or relative file path keys to permitted missing module prefixes values.
     * Source file keys must match the entire file path (e.g., `/FULL/PATH/TO/entry.js`) while package keys are the start of package name either alone or with the rest of the relative path to ultimate file (e.g., `lodash`, `@scope/pkg` or `@scope/pkg/some/path/to/file.js`).
     * Missing module prefix values may be the package name or any part of the relative path thereafter (e.g., `pkg`, `pkg/some`, `pkg/some/path/to/file.js`)
+        * Paths in forward slash (`/`) form.
 * `bailOnMissing` (`boolean`): Throw error if missing static import. (Default: `true`). If false, misses are added to `misses` object.
 * `includeSourceMaps` (`boolean`): Include source map resolved file paths from control comments. File paths are not actually checked to see if present.  (Default: `false`)
     * Source mapping URLs are only included and resolved if they are of the form `//# sourceMappingURL=<url>` or `//@ sourceMappingURL=<url>` and have a relative / absolute on-disk path (that is resolved relative to source file containing the comment). URL values starting with `http://` or `https://` are ignored.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ _Parameters_:
 
 * `srcPath` (`string`): source file path to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore tracing entirely
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) absolute source file paths and (2) package prefixes to permitted missing module prefixes. Source file paths must match the entire file path (e.g., `/FULL/PATH/TO/entry.js`) while package prefixes are the start of package name and optionally more of the path (e.g., `lodash` or `@scope/pkg/some/path`).
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of (1) absolute source file paths and (2) package name or relative file path keys to permitted missing module prefixes values.
+    * Source file keys must match the entire file path (e.g., `/FULL/PATH/TO/entry.js`) while package keys are the start of package name either alone or with the rest of the relative path to ultimate file (e.g., `lodash`, `@scope/pkg` or `@scope/pkg/some/path/to/file.js`).
+    * Missing module prefix values may be the package name or any part of the relative path thereafter (e.g., `pkg`, `pkg/some`, `pkg/some/path/to/file.js`)
 * `bailOnMissing` (`boolean`): Throw error if missing static import. (Default: `true`). If false, misses are added to `misses` object.
 * `includeSourceMaps` (`boolean`): Include source map resolved file paths from control comments. File paths are not actually checked to see if present.  (Default: `false`)
     * Source mapping URLs are only included and resolved if they are of the form `//# sourceMappingURL=<url>` or `//@ sourceMappingURL=<url>` and have a relative / absolute on-disk path (that is resolved relative to source file containing the comment). URL values starting with `http://` or `https://` are ignored.
@@ -67,7 +69,7 @@ _Parameters_:
 
 * `srcPaths` (`Array<string>`): source file paths to trace
 * `ignores` (`Array<string>`): list of package prefixes to ignore
-* `allowMissing` (`Object.<string, Array<string>`): Mapping of source file paths and package prefixes to permitted missing module prefixes.
+* `allowMissing` (`Object.<string, Array<string>`): Mapping of source file paths and package names/paths to permitted missing module prefixes.
 * `bailOnMissing` (`boolean`): Throw error if missing static import.
 * `includeSourceMaps` (`boolean`): Include source map file paths from control comments
 * `extraImports` (`Object.<string, Array<string>`): Mapping of files to additional imports to trace.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -81,7 +81,7 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   }
 
   // Then try package relative path to file.
-  const srcPkgSegment = getLastPackageSegment(srcPath);
+  const srcPkgSegment = getLastPackageSegment(toPosixPath(srcPath));
   if (srcPkgSegment) {
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkgSegment] })) {
       return true;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -81,7 +81,7 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   }
 
   // Then try package relative path to file.
-  const srcPkgSegment = getLastPackageSegment(toPosixPath(srcPath));
+  const srcPkgSegment = toPosixPath(getLastPackageSegment(srcPath));
   if (srcPkgSegment) {
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkgSegment] })) {
       return true;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -63,23 +63,19 @@ const getExtraImports = ({ srcPath, _extraImports }) => {
   return new Set();
 };
 
-const matchesAllowed = ({ allowed, depName }) =>
+const matchesAllowed = ({ depName, allowed }) =>
   allowed && allowed.some(matchesPkgPrefix(depName));
 
 const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
-  let allowed;
-
   // Try full source path match first.
-  allowed = allowMissing[path.resolve(srcPath)];
-  if (matchesAllowed({ allowed, depName })) {
+  if (matchesAllowed({ depName, allowed: allowMissing[path.resolve(srcPath)] })) {
     return true;
   }
 
   // Then try package name.
   const srcPkg = getLastPackage(srcPath);
   if (srcPkg) {
-    allowed = allowMissing[srcPkg];
-    if (matchesAllowed({ allowed, depName })) {
+    if (matchesAllowed({ depName, allowed: allowMissing[srcPkg] })) {
       return true;
     }
   }
@@ -87,8 +83,7 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   // Then try package relative path to file.
   const srcPkgSegment = getLastPackageSegment(srcPath);
   if (srcPkgSegment) {
-    allowed = allowMissing[srcPkgSegment];
-    if (matchesAllowed({ allowed, depName })) {
+    if (matchesAllowed({ depName, allowed: allowMissing[srcPkgSegment] })) {
       return true;
     }
   }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -23,7 +23,7 @@ const sortObj = (obj) => uniq(Object.keys(obj)).reduce((memo, key) => {
   memo[key] = obj[key];
   return memo;
 }, {});
-const toPosixPath = (file) => !file ? file : path.normalize(file.replace(/\\/g, "/"));
+const toPosixPath = (file) => !file ? file : path.normalize(file).replace(/\\/g, "/");
 
 // The dependency file name matches a configuration package prefix.
 // Only allow:

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -63,19 +63,29 @@ const getExtraImports = ({ srcPath, _extraImports }) => {
   return new Set();
 };
 
+const matchesAllowed = ({ allowed, depName }) =>
+  allowed && allowed.some(matchesPkgPrefix(depName));
+
 const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   // Try full source path match first.
   let allowed = allowMissing[path.resolve(srcPath)];
+  if (matchesAllowed({ allowed, depName })) {
+    return true;
+  }
 
   // Then try package name.
-  if (!allowed) {
-    const srcPkg = getLastPackage(srcPath);
-    if (srcPkg) {
-      allowed = allowMissing[srcPkg];
+  const srcPkg = getLastPackage(srcPath);
+  if (srcPkg) {
+    allowed = allowMissing[srcPkg];
+    if (matchesAllowed({ allowed, depName })) {
+      return true;
     }
   }
 
-  return allowed && allowed.some(matchesPkgPrefix(depName));
+  // Then try package relative path to file.
+
+  // Default
+  return false;
 };
 
 // HELPER: Recursively track and trace dependency paths.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -67,8 +67,10 @@ const matchesAllowed = ({ allowed, depName }) =>
   allowed && allowed.some(matchesPkgPrefix(depName));
 
 const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
+  let allowed;
+
   // Try full source path match first.
-  let allowed = allowMissing[path.resolve(srcPath)];
+  allowed = allowMissing[path.resolve(srcPath)];
   if (matchesAllowed({ allowed, depName })) {
     return true;
   }
@@ -83,6 +85,13 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   }
 
   // Then try package relative path to file.
+  const srcPkgSegment = getLastPackageSegment(srcPath);
+  if (srcPkgSegment) {
+    allowed = allowMissing[srcPkgSegment];
+    if (matchesAllowed({ allowed, depName })) {
+      return true;
+    }
+  }
 
   // Default
   return false;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -83,8 +83,6 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   // Then try package relative path to file.
   const srcPkgSegment = toPosixPath(getLastPackageSegment(srcPath));
   if (srcPkgSegment) {
-    // eslint-disable-next-line no-console,no-magic-numbers,max-len
-    console.log("TODO HERE", JSON.stringify({ srcPath, srcPkg, srcPkgSegment, depName, allowMissing }, null, 2));
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkgSegment] })) {
       return true;
     }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -74,6 +74,8 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
 
   // Then try package name.
   const srcPkg = getLastPackage(srcPath);
+  // eslint-disable-next-line no-console
+  console.log("TODO HERE", { srcPath, srcPkg, depName });
   if (srcPkg) {
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkg] })) {
       return true;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -74,8 +74,6 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
 
   // Then try package name.
   const srcPkg = getLastPackage(srcPath);
-  // eslint-disable-next-line no-console,no-magic-numbers
-  console.log("TODO HERE", JSON.stringify({ srcPath, srcPkg, depName, allowMissing }, null, 2));
   if (srcPkg) {
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkg] })) {
       return true;
@@ -85,6 +83,8 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
   // Then try package relative path to file.
   const srcPkgSegment = toPosixPath(getLastPackageSegment(srcPath));
   if (srcPkgSegment) {
+    // eslint-disable-next-line no-console,no-magic-numbers,max-len
+    console.log("TODO HERE", JSON.stringify({ srcPath, srcPkg, srcPkgSegment, depName, allowMissing }, null, 2));
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkgSegment] })) {
       return true;
     }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -74,8 +74,8 @@ const isAllowedMiss = ({ depName, srcPath, allowMissing }) => {
 
   // Then try package name.
   const srcPkg = getLastPackage(srcPath);
-  // eslint-disable-next-line no-console
-  console.log("TODO HERE", { srcPath, srcPkg, depName });
+  // eslint-disable-next-line no-console,no-magic-numbers
+  console.log("TODO HERE", JSON.stringify({ srcPath, srcPkg, depName, allowMissing }, null, 2));
   if (srcPkg) {
     if (matchesAllowed({ depName, allowed: allowMissing[srcPkg] })) {
       return true;

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1077,8 +1077,8 @@ describe("lib/trace", () => {
       expect(misses).to.eql({});
     });
 
-    // https://github.com/FormidableLabs/trace-deps/issues/49
-    it.only("handles misses with package relative paths and prefix values", async () => {
+    // Regression test: https://github.com/FormidableLabs/trace-deps/issues/49
+    it("handles misses with package relative paths and prefix values", async () => {
       mock({
         "hi.js": `
           require("pkg");

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1100,9 +1100,9 @@ describe("lib/trace", () => {
             `,
             nested: {
               "two.js": `
-              require("missing/path/b");
-              require("missing-in-two");
-              // TODO_REENABLE require("missing-in-two-with-path/path/to/file.js");
+                require("missing/path/b");
+                require("missing-in-two");
+                require("missing-in-two-with-path/path/to/file.js");
             `
             }
           }

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1102,7 +1102,7 @@ describe("lib/trace", () => {
               "two.js": `
               require("missing/path/b");
               require("missing-in-two");
-              require("missing-in-two-with-path/path/to/file.js");
+              // TODO_REENABLE require("missing-in-two-with-path/path/to/file.js");
             `
             }
           }

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1410,7 +1410,7 @@ describe("lib/trace", () => {
         extraImports: {
           // Absolute path, so application source file with **full match**
           // Use win32 path.
-          [path.resolve(".\\lib\\middle\\ho.js")]: [
+          [path.resolve("./lib/middle/ho.js").replace(/\//g, "\\")]: [
             "../extra/file",
             "extra-pkg-app/nested/path"
           ],


### PR DESCRIPTION
Bit of a bug, bit of a feature 😉 

- Change language for `allowMissing` keys for package from "package names or prefixes" to "package names or relative file path from package". Normally, this might be a breaking change, but as anything but a straight package name *ever* worked up until now, we'll call it a bug and not do a major bump.
- Implement relative file paths from last package.