### PR TITLE
Test: Bandaid for mock-fs + node 16.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        # TODO: mock-fs is broken on Node 16.3+
+        # https://github.com/FormidableLabs/trace-deps/issues/61
+        node-version: [12.x, 14.x, 16.2.0]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hard code last known working version of Node 16 in CI. For #61 