### PR TITLE
Bug: Don't apply `exports` to relative local imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Bug: Do not apply `package.json:exports` resolution to relative local file imports.
+  [#70](https://github.com/FormidableLabs/trace-deps/issues/70)
+
 ## 0.4.3
 
 * Bug: Handle (and ignore) additional passthrough wildcard `{ "./*": "./*.js" }`

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -52,10 +52,6 @@ const CONDITIONS = [
 const PASSTHROUGH_EXPORTS = {
   "./": new Set([
     "./"
-  ]),
-  "./*": new Set([
-    "./*",
-    "./*.js"
   ])
 };
 
@@ -271,6 +267,8 @@ const _resolveDep = async ({
             cond = cond[0];
           }
 
+          // TODO: MOVE THIS UP???
+
           // Special case handle "passthrough" export configuration to make
           // modern ESM act like old file-based CommonJS.
           //
@@ -297,6 +295,15 @@ const _resolveDep = async ({
               delete pkg.exports[key];
             }
           });
+
+          // TODO: MOVE THIS UP???
+          // Short circuit if dependency is relative.
+          // https://nodejs.org/api/esm.html#resolver-algorithm-specification
+          // > Otherwise, if specifier starts with "/", "./" or "../", then
+          // >   Set resolved to the URL resolution of specifier relative to parentURL.
+          if (depName.startsWith("/") || depName.startsWith("./") || depName.startsWith("../")) {
+            return;
+          }
 
           let relPath;
           try {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -249,6 +249,16 @@ const _resolveDep = async ({
         return pkg;
       }
 
+      // Short circuit if dependency is relative.
+      // https://nodejs.org/api/esm.html#resolver-algorithm-specification
+      // > Otherwise, if specifier starts with "/", "./" or "../", then
+      // >   Set resolved to the URL resolution of specifier relative to parentURL.
+      const isRelative
+        = depName.startsWith("/")
+        || depName.startsWith("./")
+        || depName.startsWith("../")
+      ;
+
       // Only add exports from the _root_ package.json for a given module.
       // From basic experiments, if we have:
       //
@@ -258,51 +268,41 @@ const _resolveDep = async ({
       // ```
       //
       // The **root** one (`ROOT/nested/from-root.js`) always wins.
-      if (!pkgPaths.length) {
+      if (!pkgPaths.length && !isRelative) {
         const pkgDir = path.dirname(pkgfile);
+
+        // Special case handle "passthrough" export configuration to make
+        // modern ESM act like old file-based CommonJS.
+        //
+        // Our approach is to simply ignore these declarations since the
+        // `resolve` library takes care of the straight path-based file
+        // resolution already and there's nothing _different_ we expect
+        // to happen with an export mapping.
+        //
+        // **NOTE**: Mutates `package.json`.
+        //
+        // From: https://nodejs.org/api/packages.html#packages_package_entry_points
+        // > As a last resort, package encapsulation can be disabled entirely
+        // > by creating an export for the root of the package "./*": "./*".
+        // > This exposes every file in the package at the cost of disabling
+        // > the encapsulation and potential tooling benefits this provides.
+        // > As the ES Module loader in Node.js enforces the use of the full
+        // > specifier path, exporting the root rather than being explicit
+        // > about entry is less expressive than either of the prior examples.
+        // > Not only is encapsulation lost but module consumers are unable to
+        // > import feature from 'my-mod/feature' as they need to provide the
+        // > full path import feature from 'my-mod/feature/index.js.
+        Object.entries(PASSTHROUGH_EXPORTS).forEach(([key, vals]) => {
+          if (vals.has((pkg.exports || {})[key])) {
+            delete pkg.exports[key];
+          }
+        });
+
         CONDITIONS.forEach((cond) => {
           let resolveOpts;
           if (Array.isArray(cond)) {
             resolveOpts = cond[1];
             cond = cond[0];
-          }
-
-          // TODO: MOVE THIS UP???
-
-          // Special case handle "passthrough" export configuration to make
-          // modern ESM act like old file-based CommonJS.
-          //
-          // Our approach is to simply ignore these declarations since the
-          // `resolve` library takes care of the straight path-based file
-          // resolution already and there's nothing _different_ we expect
-          // to happen with an export mapping.
-          //
-          // **NOTE**: Mutates `package.json`.
-          //
-          // From: https://nodejs.org/api/packages.html#packages_package_entry_points
-          // > As a last resort, package encapsulation can be disabled entirely
-          // > by creating an export for the root of the package "./*": "./*".
-          // > This exposes every file in the package at the cost of disabling
-          // > the encapsulation and potential tooling benefits this provides.
-          // > As the ES Module loader in Node.js enforces the use of the full
-          // > specifier path, exporting the root rather than being explicit
-          // > about entry is less expressive than either of the prior examples.
-          // > Not only is encapsulation lost but module consumers are unable to
-          // > import feature from 'my-mod/feature' as they need to provide the
-          // > full path import feature from 'my-mod/feature/index.js.
-          Object.entries(PASSTHROUGH_EXPORTS).forEach(([key, vals]) => {
-            if (vals.has((pkg.exports || {})[key])) {
-              delete pkg.exports[key];
-            }
-          });
-
-          // TODO: MOVE THIS UP???
-          // Short circuit if dependency is relative.
-          // https://nodejs.org/api/esm.html#resolver-algorithm-specification
-          // > Otherwise, if specifier starts with "/", "./" or "../", then
-          // >   Set resolved to the URL resolution of specifier relative to parentURL.
-          if (depName.startsWith("/") || depName.startsWith("./") || depName.startsWith("../")) {
-            return;
           }
 
           let relPath;

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1942,7 +1942,6 @@ describe("lib/trace", () => {
           });
         });
 
-
         describe("no require export", () => {
           beforeEach(() => {
             createMock({

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1865,6 +1865,73 @@ describe("lib/trace", () => {
           });
         });
 
+        // Regression for: https://github.com/FormidableLabs/trace-deps/issues/70
+        describe("suffixed .mjs/.js/.cjs local paths with wildcards", () => {
+          beforeEach(() => {
+            mock({
+              "require.js": `
+                const pkg = require("pkg/index"); // => pkg/index.cjs
+              `,
+              "import.mjs": `
+                import pkg from "pkg/index"; // => pkg/index.mjs
+              `,
+              node_modules: {
+                pkg: {
+                  "package.json": stringify({
+                    name: "pkg",
+                    main: "index.js",
+                    exports: {
+                      "./*": {
+                        require: "./*.cjs",
+                        "import": "./*.mjs"
+                      }
+                    }
+                  }),
+                  "index.js": `
+                    const { sub } = require("./sub.js");
+                    module.exports.msg = "js";
+                  `,
+                  "index.cjs": `
+                    const { sub } = require("./sub.cjs");
+                    module.exports.msg = "cjs";
+                  `,
+                  "index.mjs": `
+                    import { sub } from "./sub.mjs";
+                    export const msg = "mjs";
+                  `,
+                  "sub.js": `
+                    module.exports.sub = "sub.js";
+                  `,
+                  "sub.cjs": `
+                    module.exports.sub = "sub.cjs";
+                  `,
+                  "sub.mjs": `
+                    export const sub = "sub.mjs";
+                  `
+                }
+              }
+            });
+          });
+
+          [
+            ["CJS static", "require.js"],
+            ["ESM static", "import.mjs"]
+          ].forEach(([name, srcPath]) => {
+            it(`handles ${name} imports`, async () => {
+              const { dependencies, misses } = await traceFile({ srcPath });
+
+              expect(dependencies).to.eql(fullPaths([
+                "node_modules/pkg/index.cjs",
+                "node_modules/pkg/index.js",
+                "node_modules/pkg/index.mjs",
+                "node_modules/pkg/package.json"
+              ]));
+              expect(misses).to.eql({});
+            });
+          });
+        });
+
+
         describe("no require export", () => {
           beforeEach(() => {
             createMock({

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1889,10 +1889,14 @@ describe("lib/trace", () => {
                   }),
                   "index.js": `
                     const { sub } = require("./sub.js");
+                    const { sub2 } = require("./sub-2"); // suffix inferred
+
                     module.exports.msg = "js";
                   `,
                   "index.cjs": `
                     const { sub } = require("./sub.cjs");
+                    const { sub2 } = require("./sub-2"); // suffix inferred
+
                     module.exports.msg = "cjs";
                   `,
                   "index.mjs": `
@@ -1907,6 +1911,9 @@ describe("lib/trace", () => {
                   `,
                   "sub.mjs": `
                     export const sub = "sub.mjs";
+                  `,
+                  "sub-2.js": `
+                    module.exports.sub2 = "sub2.js";
                   `
                 }
               }
@@ -1925,6 +1932,7 @@ describe("lib/trace", () => {
                 "node_modules/pkg/index.js",
                 "node_modules/pkg/index.mjs",
                 "node_modules/pkg/package.json",
+                "node_modules/pkg/sub-2.js",
                 "node_modules/pkg/sub.cjs",
                 "node_modules/pkg/sub.js",
                 "node_modules/pkg/sub.mjs"

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1924,7 +1924,10 @@ describe("lib/trace", () => {
                 "node_modules/pkg/index.cjs",
                 "node_modules/pkg/index.js",
                 "node_modules/pkg/index.mjs",
-                "node_modules/pkg/package.json"
+                "node_modules/pkg/package.json",
+                "node_modules/pkg/sub.cjs",
+                "node_modules/pkg/sub.js",
+                "node_modules/pkg/sub.mjs"
               ]));
               expect(misses).to.eql({});
             });


### PR DESCRIPTION
Do not apply `package.json:exports` resolution to relative local file imports. Fixes #70 