### PR TITLE
Bug: Handle built-in Node.js library detection and removal when `bailIfMissing: false`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Bug: Handle built-in Node.js library detection and removal when `bailIfMissing: false`.
+  [#76](https://github.com/FormidableLabs/trace-deps/pull/76)
+
 ## 0.4.5
 
 * Feature: Handle modern ESM input types.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -266,7 +266,7 @@ const _resolveDep = async ({
       // Short circuit if dependency is relative.
       // https://nodejs.org/api/esm.html#resolver-algorithm-specification
       // > Otherwise, if specifier starts with "/", "./" or "../", then
-      // >   Set resolved to the URL resolution of specifier relative to parentURL.
+      // > Set resolved to the URL resolution of specifier relative to parentURL.
       const isRelative
         = depName.startsWith("/")
         || depName.startsWith("./")
@@ -558,6 +558,7 @@ const traceFile = async ({
   // TODO(5): Consider limiting concurrent resolution.
   // https://github.com/FormidableLabs/trace-deps/issues/5
   // Start with the resolve path and any package.json used to get there.
+  //console.log("TODO REMOVE TEST", { depNames })
   const depObjs = await Promise
     .all(depNames.map((depName) => _resolveDep({
       depName,
@@ -574,7 +575,12 @@ const traceFile = async ({
       // Remove empty names (e.g., from allowed missing modules).
       .filter(Boolean)
       // Remove core standard Node.js libraries (`path`, etc.)
-      .filter(({ depPath }, i) => depPath !== depNames[i])
+      .filter(({ depPath }, i) => {
+        if (depPath === "path") {
+          console.log("TODO HERE MATCH?", { depNames, depPath, i, val: depNames[i], allPaths })
+        }
+        return depPath !== depNames[i];
+      })
     );
 
   // Extract to different types of paths.
@@ -589,6 +595,9 @@ const traceFile = async ({
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   _tracedDepPaths.add(srcPath);
+  if (depPaths.includes("path")) {
+    console.log("TODO HERE 001", { srcPath, depNames, depPaths })
+  }
   const recursed = await _recurseDeps({
     depPaths,
     ignores,
@@ -598,6 +607,9 @@ const traceFile = async ({
     _extraImports,
     _tracedDepPaths
   });
+  if (depPaths.includes("path")) {
+    console.log("TODO HERE 002", { srcPath })
+  }
 
   results.misses = sortObj(Object.assign(results.misses, recursed.misses));
   results.dependencies = uniq([].concat(

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -558,7 +558,6 @@ const traceFile = async ({
   // TODO(5): Consider limiting concurrent resolution.
   // https://github.com/FormidableLabs/trace-deps/issues/5
   // Start with the resolve path and any package.json used to get there.
-  //console.log("TODO REMOVE TEST", { depNames })
   const depObjs = await Promise
     .all(depNames.map((depName) => _resolveDep({
       depName,
@@ -572,14 +571,14 @@ const traceFile = async ({
     })))
     // Post-resolution processing.
     .then((allPaths) => allPaths
-      // Remove empty names (e.g., from allowed missing modules).
-      .filter(Boolean)
-      // Remove core standard Node.js libraries (`path`, etc.)
-      .filter(({ depPath }, i) => {
-        if (depPath === "path") {
-          console.log("TODO HERE MATCH?", { depNames, depPath, i, val: depNames[i], allPaths })
+      .filter((depObj, i) => {
+        // Remove empty names (e.g., from allowed missing modules).
+        if (!depObj) {
+          return false;
         }
-        return depPath !== depNames[i];
+
+        // Remove core standard Node.js libraries (`path`, etc.)
+        return depObj.depPath !== depNames[i];
       })
     );
 
@@ -595,9 +594,6 @@ const traceFile = async ({
 
   // Aggregate all resolved deps and recurse into each file and resolve further.
   _tracedDepPaths.add(srcPath);
-  if (depPaths.includes("path")) {
-    console.log("TODO HERE 001", { srcPath, depNames, depPaths })
-  }
   const recursed = await _recurseDeps({
     depPaths,
     ignores,
@@ -607,9 +603,6 @@ const traceFile = async ({
     _extraImports,
     _tracedDepPaths
   });
-  if (depPaths.includes("path")) {
-    console.log("TODO HERE 002", { srcPath })
-  }
 
   results.misses = sortObj(Object.assign(results.misses, recursed.misses));
   results.dependencies = uniq([].concat(

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -1675,23 +1675,13 @@ describe("lib/trace", () => {
               "index.js": `
                 require("./one");
                 require("assert");
-                require("two");
+                // Non-existent directory.
+                require("one/bad");
                 require("path");
                 module.exports = 'one';
               `,
               "one.js": `
                 module.exports = 'one';
-              `
-            },
-            two: {
-              "package.json": stringify({
-                main: "index.js"
-              }),
-              "index.js": `
-                module.exports = 'two';
-              `,
-              "two.js": `
-                module.exports = 'two';
               `
             }
           }
@@ -1702,7 +1692,8 @@ describe("lib/trace", () => {
           srcPath,
           ignores: [
             "two"
-          ]
+          ],
+          bailOnMissing: false
         });
         expect(dependencies).to.eql(fullPaths([
           "ho.js",
@@ -1711,9 +1702,12 @@ describe("lib/trace", () => {
           "node_modules/one/one.js",
           "node_modules/one/package.json"
         ]));
-
-        expect(missesMap({ misses })).to.be.eql({});
-      })
+        expect(missesMap({ misses })).to.be.eql(resolveObjKeys({
+          "node_modules/one/index.js": [
+            "one/bad"
+          ]
+        }));
+      });
     });
 
     describe("modern ESM exports", () => {

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -671,6 +671,10 @@ describe("lib/trace", () => {
             require.resolve(\`interpolated_\${variableResolve}\`);
             require.resolve("binary" + "-expression");
             require.resolve("binary" + variableResolve);
+
+            // Node.js built-ins we should ignore
+            require("path");
+            require("net");
           `,
           node_modules: {
             one: {

--- a/test/lib/trace.spec.js
+++ b/test/lib/trace.spec.js
@@ -200,6 +200,63 @@ describe("lib/trace", () => {
         }));
       });
 
+      it("resolves built-ins correctly with bailOnMissing=false", async () => {
+        mock({
+          "hi.js": `
+            require("./ho");
+            require("path");
+          `,
+          "ho.js": `
+            require("./hum");
+            require("assert");
+            require("one");
+            require("path");
+          `,
+          "hum.js": `
+            require("path");
+          `,
+          node_modules: {
+            one: {
+              "package.json": stringify({
+                main: "index.js"
+              }),
+              "index.js": `
+                require("./one");
+                require("assert");
+                // Non-existent directory.
+                require("one/bad");
+                require("path");
+                module.exports = 'one';
+              `,
+              "one.js": `
+                module.exports = 'one';
+              `
+            }
+          }
+        });
+
+        const srcPath = "hi.js";
+        const { dependencies, misses } = await traceFile({
+          srcPath,
+          ignores: [
+            "two"
+          ],
+          bailOnMissing: false
+        });
+        expect(dependencies).to.eql(fullPaths([
+          "ho.js",
+          "hum.js",
+          "node_modules/one/index.js",
+          "node_modules/one/one.js",
+          "node_modules/one/package.json"
+        ]));
+        expect(missesMap({ misses })).to.be.eql(resolveObjKeys({
+          "node_modules/one/index.js": [
+            "one/bad"
+          ]
+        }));
+      });
+
       it("handles try/catch misses requires", async () => {
         mock({
           "hi.js": `
@@ -1650,63 +1707,6 @@ describe("lib/trace", () => {
         ]));
 
         expect(missesMap({ misses })).to.be.eql({});
-      });
-
-      it("resolves built-ins correctly with mixed relative paths", async () => {
-        mock({
-          "hi.js": `
-            require("./ho");
-            require("path");
-          `,
-          "ho.js": `
-            require("./hum");
-            require("assert");
-            require("one");
-            require("path");
-          `,
-          "hum.js": `
-            require("path");
-          `,
-          node_modules: {
-            one: {
-              "package.json": stringify({
-                main: "index.js"
-              }),
-              "index.js": `
-                require("./one");
-                require("assert");
-                // Non-existent directory.
-                require("one/bad");
-                require("path");
-                module.exports = 'one';
-              `,
-              "one.js": `
-                module.exports = 'one';
-              `
-            }
-          }
-        });
-
-        const srcPath = "hi.js";
-        const { dependencies, misses } = await traceFile({
-          srcPath,
-          ignores: [
-            "two"
-          ],
-          bailOnMissing: false
-        });
-        expect(dependencies).to.eql(fullPaths([
-          "ho.js",
-          "hum.js",
-          "node_modules/one/index.js",
-          "node_modules/one/one.js",
-          "node_modules/one/package.json"
-        ]));
-        expect(missesMap({ misses })).to.be.eql(resolveObjKeys({
-          "node_modules/one/index.js": [
-            "one/bad"
-          ]
-        }));
       });
     });
 


### PR DESCRIPTION
To see issue, run `trace-deps` on https://unpkg.com/browse/next@12.0.10/dist/compiled/webpack/bundle5.js like:

```sh
$ node bin/trace-deps.js trace -i /Users/rye/scm/fmd/nextjs-serverless-demo/node_modules/next/dist/compiled/webpack/bundle5.js
```