### PR TITLE
Feature: Use modern ECMAScript parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes
 
 ## UNRELEASED
 
-* Feature: Support `latest` ECMAScript features.
+* Feature: Support `latest` ECMAScript features. Remove `acorn-node` and switch to `acorn` + `acorn-walk` with `ecmaVersion: "latest"` for all the latest ECMAScript features.
 
 ## 0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Support `latest` ECMAScript features.
+
 ## 0.4.8
 
 * Bug: Remove `null` file results when passing a `packageIterator` to `resolve` library (manifests as of `resolve@1.22.0`).

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -5,7 +5,7 @@
  */
 const path = require("path");
 
-const acornWalk = require("acorn-node/walk");
+const acornWalk = require("acorn-walk");
 const walk = acornWalk.simple;
 
 // Custom traversal + visitors.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { promisify } = require("util");
 
-const { parse } = require("acorn-node");
+const { parse } = require("acorn");
 const resolve = promisify(require("resolve"));
 const resolveExports = require("resolve.exports");
 
@@ -537,7 +537,7 @@ const traceFile = async ({
       sourceType: "module",
       allowAwaitOutsideFunction: true, // for top-level await
       locations: true,
-      // TODO HERE: ecmaVersion: "latest", // fully modern, hipster ECMAScript
+      ecmaVersion: "latest", // fully modern, hipster ECMAScript
       onComment
     });
   } catch (modErr) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -537,6 +537,7 @@ const traceFile = async ({
       sourceType: "module",
       allowAwaitOutsideFunction: true, // for top-level await
       locations: true,
+      // TODO HERE: ecmaVersion: "latest", // fully modern, hipster ECMAScript
       onComment
     });
   } catch (modErr) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "acorn-node": "^2.0.1",
+    "acorn": "^8.7.0",
+    "acorn-walk": "^8.2.0",
     "resolve": "^1.22.0",
     "resolve.exports": "^1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,24 +503,10 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
-acorn-node@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-2.0.1.tgz#4a93ba32335950da9250175c654721f20f3375a7"
-  integrity sha512-VLR5sHqjk+8c5hrKeP2fWaIHb8eewsoxnZ8r2qpwRHXMHuC7KyOPflnOx9dLssVQUurzJ7rO0OzIFjHcndafWw==
-  dependencies:
-    acorn "^7.0.0"
-    acorn-walk "^7.0.0"
-    xtend "^4.0.2"
-
-acorn-walk@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
-  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
-
-acorn@^7.0.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^8.7.0:
   version "8.7.0"
@@ -2736,11 +2722,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-xtend@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
* Replaces https://github.com/FormidableLabs/trace-deps/pull/80
* Replace `acorn-node` with `acorn` + `acorn-walk`
* Enable `ecmaScript: "latest"`

@Saniol - Thanks for your details and work in #80. I took a slightly different direction with this PR and just went to support "all latest" ECMAScript. If you have a moment can you kick the tires on this branch and let me know how it works for you? Thanks!